### PR TITLE
feat: interop tests - verify VPs for danubetech & digitalbazaar

### DIFF
--- a/test/bdd/features/verifier_e2e_api.feature
+++ b/test/bdd/features/verifier_e2e_api.feature
@@ -11,7 +11,7 @@ Feature: Verifier VC REST API
   @verifyCred_api
   Scenario Outline: Verify Credential
     Given "Alice" has her "<credential>" verified as "<verifiable credential>"
-    Then  Employer verifies the credential provided by "Alice"
+    Then  Employer verifies the verifiable credential provided by "Alice"
     Examples:
     Examples:
       | credential                   | verifiable credential  |
@@ -25,11 +25,13 @@ Feature: Verifier VC REST API
 
   @verifyPresentation_api
   Scenario Outline: Verify Presentation
-    Given "Alice" has her "<credential>" presentable as "<verifiable presentation>"
-    Then  Employer verifies the presentation provided by "Alice"
+    Given "Alice" has her "<credential>" verified as "<verifiable credential>" and presentable as "<verifiable presentation>"
+    Then  Employer verifies the verifiable presentation provided by "Alice"
     Examples:
-      | credential                   | verifiable presentation |
-      | university_degree.json       |                         |
-      | permanent_resident_card.json |                         |
-      | university_degree.json       | transmute_vp1.json      |
-      | permanent_resident_card.json | transmute_vp2.json      |
+      | credential                   | verifiable credential | verifiable presentation |
+      | university_degree.json       |                       |                         |
+      | permanent_resident_card.json |                       |                         |
+      | university_degree.json       | transmute_vc1.json    |                         |
+      | permanent_resident_card.json | transmute_vc2.json    |                         |
+      | university_degree.json       | transmute_vc1.json    | transmute_vp1.json      |
+      | permanent_resident_card.json | transmute_vc2.json    | transmute_vp2.json      |

--- a/test/bdd/pkg/verifier/verifier_steps.go
+++ b/test/bdd/pkg/verifier/verifier_steps.go
@@ -37,8 +37,8 @@ func NewSteps(ctx *context.BDDContext) *Steps {
 
 // RegisterSteps registers agent steps
 func (e *Steps) RegisterSteps(s *godog.Suite) {
-	s.Step(`^Employer verifies the credential provided by "([^"]*)"$`, e.credentialsVerification)
-	s.Step(`^Employer verifies the presentation provided by "([^"]*)"$`, e.createAndVerifyPresentation)
+	s.Step(`^Employer verifies the verifiable credential provided by "([^"]*)"$`, e.credentialsVerification)
+	s.Step(`^Employer verifies the verifiable presentation provided by "([^"]*)"$`, e.createAndVerifyPresentation)
 }
 
 func (e *Steps) credentialsVerification(user string) error {


### PR DESCRIPTION
Unable to locate endpoints for creating verificable presentations using
digital bazaar and danube tech endpoints. So created VPs for those VCs
using our systems.

Also added extra exmaple for creating VPs using transumute VCs.

- closes #203

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>