### PR TITLE
feat: use pkg/errors instead of error

### DIFF
--- a/component/event/bus_test.go
+++ b/component/event/bus_test.go
@@ -8,12 +8,13 @@ package event
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/require"
 

--- a/component/event/go.mod
+++ b/component/event/go.mod
@@ -7,6 +7,7 @@ go 1.19
 
 require (
 	github.com/hyperledger/aries-framework-go v0.1.9-0.20220921220826-52d9990bb684
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
 	github.com/trustbloc/vcs v0.0.0-00010101000000-000000000000
 )

--- a/component/event/go.sum
+++ b/component/event/go.sum
@@ -5,6 +5,8 @@ github.com/hyperledger/aries-framework-go v0.1.9-0.20220921220826-52d9990bb684 h
 github.com/hyperledger/aries-framework-go v0.1.9-0.20220921220826-52d9990bb684/go.mod h1:28aD9QTgVjeAl86vHNFwkOYwQwZiTrrODMpjE2PYz3M=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220728221432-bc126d50cdf9 h1:Dzmx6uOElcBlpXZwIafb2SVeE0/wdSUEZJEROZ8tQl8=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220728221432-bc126d50cdf9/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.mod
+++ b/go.mod
@@ -28,12 +28,14 @@ require (
 	github.com/ory/dockertest/v3 v3.9.0
 	github.com/ory/fosite v0.42.3-0.20220923124412-e98c0d745a0c
 	github.com/piprate/json-gold v0.4.1
+	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.29.0
 	github.com/spf13/cobra v1.5.0
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693
 	github.com/stretchr/testify v1.8.0
 	github.com/trustbloc/edge-core v0.1.9-0.20220718150010-aa7941986372
 	github.com/trustbloc/kms v0.1.9-0.20220927102932-412f152996fa
+	github.com/trustbloc/orb v1.0.0-rc2.0.20220811160855-64ffb892b32b
 	go.mongodb.org/mongo-driver v1.10.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 )
@@ -124,7 +126,6 @@ require (
 	github.com/ory/x v0.0.477 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
@@ -139,14 +140,12 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
 	github.com/tidwall/gjson v1.14.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/sjson v1.2.4 // indirect
-	github.com/trustbloc/orb v1.0.0-rc2.0.20220811160855-64ffb892b32b // indirect
 	github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220729143551-6cda4cea3bf5 // indirect
 	github.com/trustbloc/vct v1.0.0-rc2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/pkg/doc/vc/crypto/crypto_test.go
+++ b/pkg/doc/vc/crypto/crypto_test.go
@@ -9,10 +9,11 @@ package crypto
 import (
 	"crypto/ed25519"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/common/model"
 	ariescrypto "github.com/hyperledger/aries-framework-go/pkg/crypto"

--- a/pkg/doc/vc/crypto/util.go
+++ b/pkg/doc/vc/crypto/util.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"

--- a/pkg/doc/vc/status/csl/csl.go
+++ b/pkg/doc/vc/status/csl/csl.go
@@ -7,10 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package csl
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/trustbloc/vcs/pkg/doc/vc"
 	vcsstorage "github.com/trustbloc/vcs/pkg/storage"

--- a/pkg/doc/vc/vcutil/vcutil.go
+++ b/pkg/doc/vc/vcutil/vcutil.go
@@ -8,8 +8,9 @@ package vcutil
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 

--- a/pkg/kms/key/creator_test.go
+++ b/pkg/kms/key/creator_test.go
@@ -9,8 +9,9 @@ package key_test
 import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
-	"errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries"

--- a/pkg/kms/signer/arieskms_test.go
+++ b/pkg/kms/signer/arieskms_test.go
@@ -7,9 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package signer
 
 import (
-	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/google/tink/go/keyset"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"

--- a/pkg/ld/document_loader_test.go
+++ b/pkg/ld/document_loader_test.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package ld_test
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	mockldstore "github.com/hyperledger/aries-framework-go/pkg/mock/ld"
 	ldstore "github.com/hyperledger/aries-framework-go/pkg/store/ld"

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package lifecycle
 
 import (
-	"errors"
 	"sync/atomic"
+
+	"github.com/pkg/errors"
 
 	"github.com/trustbloc/edge-core/pkg/log"
 

--- a/pkg/restapi/resterr/error_test.go
+++ b/pkg/restapi/resterr/error_test.go
@@ -7,9 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package resterr
 
 import (
-	"errors"
 	"net/http"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/restapi/resterr/handler_test.go
+++ b/pkg/restapi/resterr/handler_test.go
@@ -7,10 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package resterr
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"

--- a/pkg/restapi/v1/common/common_test.go
+++ b/pkg/restapi/v1/common/common_test.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"

--- a/pkg/restapi/v1/issuer/controller.go
+++ b/pkg/restapi/v1/issuer/controller.go
@@ -10,10 +10,11 @@ SPDX-License-Identifier: Apache-2.0
 package issuer
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/labstack/echo/v4"

--- a/pkg/restapi/v1/issuer/controller_test.go
+++ b/pkg/restapi/v1/issuer/controller_test.go
@@ -10,11 +10,12 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"

--- a/pkg/restapi/v1/util/auth.go
+++ b/pkg/restapi/v1/util/auth.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package util
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/labstack/echo/v4"
 

--- a/pkg/restapi/v1/verifier/controller.go
+++ b/pkg/restapi/v1/verifier/controller.go
@@ -11,11 +11,12 @@ package verifier
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jwt"

--- a/pkg/restapi/v1/verifier/controller_test.go
+++ b/pkg/restapi/v1/verifier/controller_test.go
@@ -11,12 +11,13 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	_ "embed"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jwt"

--- a/pkg/service/credentialstatus/credentialstatus_service_test.go
+++ b/pkg/service/credentialstatus/credentialstatus_service_test.go
@@ -11,11 +11,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
-	"errors"
 	"io"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"

--- a/pkg/service/didconfiguration/didconfiguration_service.go
+++ b/pkg/service/didconfiguration/didconfiguration_service.go
@@ -10,8 +10,9 @@ package didconfiguration
 
 import (
 	"context"
-	"errors"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"

--- a/pkg/service/didconfiguration/didconfiguration_service_test.go
+++ b/pkg/service/didconfiguration/didconfiguration_service_test.go
@@ -2,8 +2,9 @@ package didconfiguration
 
 import (
 	"context"
-	"errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"

--- a/pkg/service/issuecredential/issuecredential_service_test.go
+++ b/pkg/service/issuecredential/issuecredential_service_test.go
@@ -9,10 +9,11 @@ package issuecredential
 import (
 	"crypto/ed25519"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/aries-framework-go/pkg/common/model"

--- a/pkg/service/oidc4vp/oidc4vp_service.go
+++ b/pkg/service/oidc4vp/oidc4vp_service.go
@@ -9,9 +9,10 @@ SPDX-License-Identifier: Apache-2.0
 package oidc4vp
 
 import (
-	"errors"
 	"fmt"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/google/uuid"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"

--- a/pkg/service/oidc4vp/oidc4vp_service_test.go
+++ b/pkg/service/oidc4vp/oidc4vp_service_test.go
@@ -8,10 +8,11 @@ package oidc4vp_test
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"

--- a/pkg/service/oidc4vp/txmanager_test.go
+++ b/pkg/service/oidc4vp/txmanager_test.go
@@ -7,9 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package oidc4vp_test
 
 import (
-	"errors"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"

--- a/pkg/service/verifycredential/verifycredential_service.go
+++ b/pkg/service/verifycredential/verifycredential_service.go
@@ -10,9 +10,10 @@ package verifycredential
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"

--- a/pkg/service/verifycredential/verifycredential_service_test.go
+++ b/pkg/service/verifycredential/verifycredential_service_test.go
@@ -8,8 +8,9 @@ package verifycredential
 
 import (
 	_ "embed"
-	"errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"

--- a/pkg/service/verifypresentation/verifypresentation_service.go
+++ b/pkg/service/verifypresentation/verifypresentation_service.go
@@ -10,8 +10,9 @@ package verifypresentation
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"

--- a/pkg/service/verifypresentation/verifypresentation_service_test.go
+++ b/pkg/service/verifypresentation/verifypresentation_service_test.go
@@ -8,9 +8,10 @@ package verifypresentation
 
 import (
 	_ "embed"
-	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"

--- a/pkg/storage/ariesprovider/ariesprovider_test.go
+++ b/pkg/storage/ariesprovider/ariesprovider_test.go
@@ -8,8 +8,9 @@ package ariesprovider_test
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/trustbloc/vcs/pkg/storage/ariesprovider"
 

--- a/pkg/storage/mongodb/oidc4vptxstore/oidc4vp_tx_store.go
+++ b/pkg/storage/mongodb/oidc4vptxstore/oidc4vp_tx_store.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package oidc4vptxstore
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
 	"go.mongodb.org/mongo-driver/bson"

--- a/pkg/storage/mongodbprovider/csl.go
+++ b/pkg/storage/mongodbprovider/csl.go
@@ -8,7 +8,8 @@ package mongodbprovider
 
 import (
 	"encoding/json"
-	"errors"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"go.mongodb.org/mongo-driver/bson"

--- a/pkg/storage/mongodbprovider/holderprofile.go
+++ b/pkg/storage/mongodbprovider/holderprofile.go
@@ -8,7 +8,8 @@ package mongodbprovider //nolint:dupl // Similar code but different types
 
 import (
 	"encoding/json"
-	"errors"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"github.com/trustbloc/vcs/pkg/storage"

--- a/pkg/storage/mongodbprovider/issuerprofile.go
+++ b/pkg/storage/mongodbprovider/issuerprofile.go
@@ -8,7 +8,8 @@ package mongodbprovider //nolint:dupl // Similar code but different types
 
 import (
 	"encoding/json"
-	"errors"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"github.com/trustbloc/vcs/pkg/storage"

--- a/pkg/storage/mongodbprovider/masterkey.go
+++ b/pkg/storage/mongodbprovider/masterkey.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package mongodbprovider
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"github.com/trustbloc/vcs/pkg/storage"

--- a/pkg/storage/mongodbprovider/vc.go
+++ b/pkg/storage/mongodbprovider/vc.go
@@ -8,8 +8,9 @@ package mongodbprovider
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/trustbloc/vcs/pkg/storage"

--- a/pkg/storage/mongodbprovider/verifierprofile.go
+++ b/pkg/storage/mongodbprovider/verifierprofile.go
@@ -8,7 +8,8 @@ package mongodbprovider //nolint:dupl // Similar code but different types
 
 import (
 	"encoding/json"
-	"errors"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"github.com/trustbloc/vcs/pkg/storage"

--- a/pkg/storage/redis/oidctxstore/tx_nonce_store.go
+++ b/pkg/storage/redis/oidctxstore/tx_nonce_store.go
@@ -8,9 +8,10 @@ package oidctxstore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/go-redis/redis/v8"
 

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.9-0.20220921220826-52d9990bb684
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc2.0.20220811162145-47649b185a56
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85
+	github.com/pkg/errors v0.9.1
 	github.com/tidwall/gjson v1.14.0
 	github.com/trustbloc/edge-core v0.1.9-0.20220718150010-aa7941986372
 	github.com/trustbloc/vcs v0.1.8
@@ -82,7 +83,6 @@ require (
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/piprate/json-gold v0.4.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect

--- a/test/bdd/pkg/bddutil/util.go
+++ b/test/bdd/pkg/bddutil/util.go
@@ -12,13 +12,14 @@ import (
 	"crypto/tls"
 	_ "embed" //nolint:gci // required for go:embed
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	docdid "github.com/hyperledger/aries-framework-go/pkg/doc/did"


### PR DESCRIPTION
Use package https://github.com/pkg/errors instead of standard "error"
This package is drop-in replacement for "error",
This package gives some additional features like stack traces and error.cause