### PR TITLE
test: drop useless test for object-store

### DIFF
--- a/test/bdd/features/vc_dev_api.feature
+++ b/test/bdd/features/vc_dev_api.feature
@@ -17,10 +17,3 @@ Feature: Request DID Config
       | issuer      | i_myprofile_ud_es256_jwt  | jwt            |
       | verifier    | v_myprofile_ldp           | ldp            |
       | verifier    | v_myprofile_jwt           | jwt            |
-
-  Scenario Outline: Request Object Store
-    When I request object store with "<uuid>"
-    Then I receive response for object-store with status code "<statusCode>" and body "<body>"
-    Examples:
-      | uuid                      | statusCode  | body          |
-      | 63451f2358bde34a13b5d95b  | 500         | not found     |

--- a/test/bdd/pkg/vc-devapi/vc_devapi_steps.go
+++ b/test/bdd/pkg/vc-devapi/vc_devapi_steps.go
@@ -2,12 +2,10 @@ package vc_devapi
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/cucumber/godog"
 	"github.com/hyperledger/aries-framework-go/pkg/common/log"
@@ -33,9 +31,6 @@ func NewSteps(ctx *bddcontext.BDDContext) *Steps {
 func (s *Steps) RegisterSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^I request did config for "([^"]*)" with ID "([^"]*)" and type "([^"]*)"$`, s.requestDidConfig)
 	sc.Step(`^I receive response with status code "([^"]*)" for didconfig$`, s.checkResponseStatus)
-
-	sc.Step(`^I request object store with "([^"]*)"$`, s.requestObjectStore)
-	sc.Step(`^I receive response for object-store with status code "([^"]*)" and body "([^"]*)"$`, s.checkObjectStoreResponse)
 }
 
 func (s *Steps) checkResponseStatus(status string) error {
@@ -48,30 +43,6 @@ func (s *Steps) checkResponseStatus(status string) error {
 
 	if s.responseStatus != code {
 		return fmt.Errorf("expected %d, got %d", code, s.responseStatus)
-	}
-
-	return nil
-}
-
-func (s *Steps) requestObjectStore(uuid string) error {
-	url := fmt.Sprintf("http://localhost:8075/request-object/%v",
-		uuid)
-
-	return s.httpGet(url, false)
-}
-
-func (s *Steps) checkObjectStoreResponse(statusCode string, body string) error {
-	code, err := strconv.Atoi(statusCode)
-	if err != nil {
-		return fmt.Errorf("invalid status: %w", err)
-	}
-
-	if s.responseStatus != code {
-		return errors.New(fmt.Sprintf("invalid code. expected %v got %v", statusCode, s.responseStatus))
-	}
-
-	if strings.EqualFold(string(s.responseBody), body) {
-		return errors.New(fmt.Sprintf("invalid body. expected %v got %v", body, string(s.responseBody)))
 	}
 
 	return nil


### PR DESCRIPTION
Test for this endpoint does not make sense, as it requires first to create that credentials, and this logic already covered in https://github.com/trustbloc/vcs/blob/7275a8303d1c0be9c2016963c16559bb2df8b3d0/test/bdd/pkg/v1/oidc4vp/oidc4vp.go#L118 for both creating and requesting this endpoint