### PR TITLE
feat: Add optional fields to event

### DIFF
--- a/component/event/bus_test.go
+++ b/component/event/bus_test.go
@@ -47,7 +47,7 @@ func TestEventBus_Publish(t *testing.T) {
 			}
 		}()
 
-		msg := spi.NewEvent(uuid, sourceURL, eventType, []byte(jsonMsg))
+		msg := spi.NewEventWithPayload(uuid, sourceURL, eventType, []byte(jsonMsg))
 
 		require.NoError(t, eb.Publish(topic, msg))
 
@@ -62,7 +62,7 @@ func TestEventBus_Publish(t *testing.T) {
 	})
 
 	t.Run("success - no subscribers", func(t *testing.T) {
-		msg := spi.NewEvent(uuid, sourceURL, eventType, []byte("{}"))
+		msg := spi.NewEventWithPayload(uuid, sourceURL, eventType, []byte("{}"))
 
 		require.NoError(t, eb.PublishWithOpts("no-subscribers-topic", msg, spi.WithDeliveryDelay(5*time.Second)))
 
@@ -88,7 +88,7 @@ func TestEventBus_Error(t *testing.T) {
 		require.NotNil(t, eb)
 		require.NoError(t, eb.Close())
 
-		err := eb.Publish(topic, spi.NewEvent(uuid, sourceURL, eventType, []byte(jsonMsg)))
+		err := eb.Publish(topic, spi.NewEventWithPayload(uuid, sourceURL, eventType, []byte(jsonMsg)))
 		require.True(t, errors.Is(err, lifecycle.ErrNotStarted))
 	})
 }
@@ -116,7 +116,7 @@ func TestEventBus_Close(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 250; i++ {
-			msg := spi.NewEvent(fmt.Sprintf("%s-%d", uuid, i), sourceURL, eventType, []byte(jsonMsg))
+			msg := spi.NewEventWithPayload(fmt.Sprintf("%s-%d", uuid, i), sourceURL, eventType, []byte(jsonMsg))
 
 			if err := eb.PublishWithOpts(topic, msg); err != nil {
 				if errors.Is(err, lifecycle.ErrNotStarted) {

--- a/component/event/event.go
+++ b/component/event/event.go
@@ -46,9 +46,9 @@ func (b *Bus) handleEvent(e *spi.Event) error { //nolint:gocognit
 		return nil
 	}
 
-	payload := &eventPayload{}
+	payload := eventPayload{}
 
-	if err := json.Unmarshal(*e.Data, payload); err != nil {
+	if err := json.Unmarshal(e.Data, &payload); err != nil {
 		return err
 	}
 

--- a/component/event/publisher_test.go
+++ b/component/event/publisher_test.go
@@ -30,13 +30,13 @@ func TestEventPublisher(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
 
 		_, err = eventBus.Subscribe(context.TODO(), topic)
 		require.NoError(t, err)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-2", sourceURL, eventType, []byte(jsonMsg))))
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-3", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-2", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-3", sourceURL, eventType, []byte(jsonMsg))))
 
 		done := make(chan interface{})
 
@@ -63,7 +63,7 @@ func TestEventPublisher(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		err := publisher.Publish(topic, spi.NewEvent("id-1", sourceURL, eventType, []byte(jsonMsg)))
+		err := publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg)))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "publishing error")
 	})

--- a/component/event/subscriber_test.go
+++ b/component/event/subscriber_test.go
@@ -31,9 +31,9 @@ func TestEventSubscriber(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-1", sourceURL, eventType, []byte(jsonMsg))))
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-2", sourceURL, eventType, []byte(jsonMsg))))
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-3", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-2", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-3", sourceURL, eventType, []byte(jsonMsg))))
 
 		time.Sleep(time.Second)
 	})
@@ -48,7 +48,7 @@ func TestEventSubscriber(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
 
 		time.Sleep(time.Second)
 
@@ -67,7 +67,7 @@ func TestEventSubscriber(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEvent("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
 
 		time.Sleep(time.Second)
 	})

--- a/pkg/event/spi/spi.go
+++ b/pkg/event/spi/spi.go
@@ -60,43 +60,62 @@ type Event struct {
 	// Type defines event type(required).
 	Type EventType `json:"type"`
 
-	// DataContentType is data content type(required).
-	DataContentType string `json:"datacontenttype"`
-
 	// Time defines time of occurrence(required).
 	Time *util.TimeWrapper `json:"time"`
 
-	// Data defines message(required).
-	Data *json.RawMessage `json:"data"`
+	// DataContentType is data content type(optional).
+	DataContentType string `json:"datacontenttype,omitempty"`
+
+	// Data defines message(optional).
+	Data json.RawMessage `json:"data,omitempty"`
+
+	// TransactionID defines transaction ID(optional).
+	TransactionID string `json:"txnid,omitempty"`
+
+	// Subject defines subject(optional).
+	Subject string `json:"subject,omitempty"`
+
+	// Tracing defines tracing(optional).
+	Tracing string `json:"tracing,omitempty"`
 }
 
 // Copy an event.
 func (m *Event) Copy() *Event {
 	return &Event{
 		SpecVersion:     m.SpecVersion,
-		DataContentType: m.DataContentType,
 		ID:              m.ID,
 		Source:          m.Source,
 		Type:            m.Type,
 		Time:            m.Time,
+		DataContentType: m.DataContentType,
 		Data:            m.Data,
+		TransactionID:   m.TransactionID,
+		Subject:         m.Subject,
+		Tracing:         m.Tracing,
 	}
 }
 
-// NewEvent creates a new Event.
-func NewEvent(uuid string, source string, eventType EventType, payload Payload) *Event {
-	now := time.Now()
+// NewEventWithPayload creates a new Event with payload.
+func NewEventWithPayload(uuid string, source string, eventType EventType, payload Payload) *Event {
+	event := NewEvent(uuid, source, eventType)
 
 	data := json.RawMessage(payload)
+	event.Data = data
+	event.DataContentType = "application/json"
+
+	return event
+}
+
+// NewEvent creates a new Event and sets all required fields.
+func NewEvent(uuid string, source string, eventType EventType) *Event {
+	now := time.Now()
 
 	return &Event{
-		SpecVersion:     "1.0",
-		DataContentType: "application/json",
-		ID:              uuid,
-		Source:          source,
-		Type:            eventType,
-		Time:            util.NewTime(now),
-		Data:            &data,
+		SpecVersion: "1.0",
+		ID:          uuid,
+		Source:      source,
+		Type:        eventType,
+		Time:        util.NewTime(now),
 	}
 }
 

--- a/pkg/event/spi/spi_test.go
+++ b/pkg/event/spi/spi_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package spi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvent(t *testing.T) {
+	event := NewEvent("id", "source", "type")
+	require.NotNil(t, event)
+
+	eventWithPayload := NewEventWithPayload("id", "source", "type", Payload("{}"))
+	require.NotNil(t, eventWithPayload)
+
+	eventCopy := event.Copy()
+	require.NotNil(t, eventCopy)
+}
+
+func TestOptions(t *testing.T) {
+	var opts []Option
+	opts = append(opts, WithDeliveryDelay(time.Second), WithPool(2))
+
+	var options Options
+	for _, opt := range opts {
+		opt(&options)
+	}
+}

--- a/pkg/service/oidc4ci/models.go
+++ b/pkg/service/oidc4ci/models.go
@@ -143,7 +143,6 @@ type InsertOptions struct {
 }
 
 type eventPayload struct {
-	TxID    string `json:"txID"`
 	WebHook string `json:"webHook,omitempty"`
 	Error   string `json:"error,omitempty"`
 }

--- a/pkg/service/oidc4ci/oidc4ci_service.go
+++ b/pkg/service/oidc4ci/oidc4ci_service.go
@@ -372,7 +372,6 @@ func (s *Service) createEvent(
 	e error,
 ) (*spi.Event, error) {
 	ep := eventPayload{
-		TxID:    string(tx.ID),
 		WebHook: tx.WebHookURL,
 	}
 
@@ -385,7 +384,10 @@ func (s *Service) createEvent(
 		return nil, err
 	}
 
-	return spi.NewEvent(uuid.NewString(), "oidc4ci", eventType, payload), nil
+	event := spi.NewEventWithPayload(uuid.NewString(), "oidc4ci", eventType, payload)
+	event.TransactionID = string(tx.ID)
+
+	return event, nil
 }
 
 func (s *Service) sendEvent(tx *Transaction, eventType spi.EventType) error {

--- a/pkg/service/oidc4vp/oidc4vp_service.go
+++ b/pkg/service/oidc4vp/oidc4vp_service.go
@@ -150,7 +150,6 @@ type RequestObjectRegistration struct {
 }
 
 type eventPayload struct {
-	TxID    string `json:"txID"`
 	WebHook string `json:"webHook,omitempty"`
 	Error   string `json:"error,omitempty"`
 }
@@ -184,7 +183,6 @@ func NewService(cfg *Config) *Service {
 func (s *Service) createEvent(tx *Transaction, profile *profileapi.Verifier,
 	eventType spi.EventType, e error) (*spi.Event, error) {
 	ep := eventPayload{
-		TxID:    string(tx.ID),
 		WebHook: profile.WebHook,
 	}
 
@@ -196,7 +194,11 @@ func (s *Service) createEvent(tx *Transaction, profile *profileapi.Verifier,
 	if err != nil {
 		return nil, err
 	}
-	return spi.NewEvent(uuid.NewString(), profile.URL, eventType, payload), nil
+
+	event := spi.NewEventWithPayload(uuid.NewString(), profile.URL, eventType, payload)
+	event.TransactionID = string(tx.ID)
+
+	return event, nil
 }
 
 func (s *Service) sendEvent(tx *Transaction, profile *profileapi.Verifier, eventType spi.EventType) error {

--- a/pkg/storage/mongodb/requestobjectstore/request_object_store_test.go
+++ b/pkg/storage/mongodb/requestobjectstore/request_object_store_test.go
@@ -95,7 +95,7 @@ func TestObjectStore(t *testing.T) {
 			Type:            "test4",
 			DataContentType: "test5",
 			Time:            nil,
-			Data:            &eventData,
+			Data:            eventData,
 		}
 
 		resp, err := store.Create(requestobject.RequestObject{

--- a/test/bdd/pkg/v1/oidc4vc/oidc4vp.go
+++ b/test/bdd/pkg/v1/oidc4vc/oidc4vp.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/trustbloc/vcs/pkg/event/spi"
 	"github.com/trustbloc/vcs/test/bdd/pkg/bddutil"
 )
 
@@ -33,28 +34,6 @@ const (
 	InitiateOidcInteractionURLFormat   = verifierProfileURLFormat + "/interactions/initiate-oidc"
 	RetrieveInteractionsClaimURLFormat = credentialServiceURL + "/verifier/interactions/%s/claim"
 )
-
-type Event struct {
-	// ID identifies the event(required).
-	ID string `json:"id"`
-
-	// Source is URI for producer(required).
-	Source string `json:"source"`
-
-	// Type defines event type(required).
-	Type string `json:"type"`
-
-	// DataContentType is data content type(required).
-	DataContentType string `json:"datacontenttype"`
-
-	// Data defines message(required).
-	Data *EventPayload `json:"data"`
-}
-
-type EventPayload struct {
-	TxID    string `json:"txID"`
-	WebHook string `json:"webHook,omitempty"`
-}
 
 func (s *Steps) initiateInteraction(profileName, organizationName string) error {
 	s.vpFlowExecutor = s.walletRunner.NewVPFlowExecutor()
@@ -131,7 +110,7 @@ func (s *Steps) retrieveInteractionsClaim(organizationName string) error {
 }
 
 func (s *Steps) waitForEvent(eventType string) (string, error) {
-	incoming := &Event{}
+	incoming := &spi.Event{}
 
 	for i := 0; i < pullTopicsAttemptsBeforeFail; {
 
@@ -156,8 +135,8 @@ func (s *Steps) waitForEvent(eventType string) (string, error) {
 			return "", err
 		}
 
-		if incoming.Type == eventType {
-			return incoming.Data.TxID, nil
+		if incoming.Type == spi.EventType(eventType) {
+			return incoming.TransactionID, nil
 		}
 
 		i++

--- a/test/bdd/pkg/v1/oidc4vp/oidc4vp.go
+++ b/test/bdd/pkg/v1/oidc4vp/oidc4vp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 
 	"github.com/trustbloc/vcs/pkg/doc/vc"
+	"github.com/trustbloc/vcs/pkg/event/spi"
 	"github.com/trustbloc/vcs/pkg/kms/signer"
 	"github.com/trustbloc/vcs/test/bdd/pkg/bddutil"
 )
@@ -87,28 +88,6 @@ type VPTokenClaims struct {
 	Iss   string                   `json:"iss"`
 }
 
-type Event struct {
-	// ID identifies the event(required).
-	ID string `json:"id"`
-
-	// Source is URI for producer(required).
-	Source string `json:"source"`
-
-	// Type defines event type(required).
-	Type string `json:"type"`
-
-	// DataContentType is data content type(required).
-	DataContentType string `json:"datacontenttype"`
-
-	// Data defines message(required).
-	Data *EventPayload `json:"data"`
-}
-
-type EventPayload struct {
-	TxID    string `json:"txID"`
-	WebHook string `json:"webHook,omitempty"`
-}
-
 func (e *Steps) initiateInteraction(profileName, organizationName string) error {
 	e.vpFlowExecutor = &VPFlowExecutor{
 		tlsConfig:      e.tlsConfig,
@@ -166,7 +145,7 @@ func (e *Steps) retrieveInteractionsClaim(organizationName string) error {
 }
 
 func (e *Steps) waitForEvent(eventType string) (string, error) {
-	incoming := &Event{}
+	incoming := &spi.Event{}
 
 	for i := 0; i < pullTopicsAttemptsBeforeFail; {
 
@@ -191,8 +170,8 @@ func (e *Steps) waitForEvent(eventType string) (string, error) {
 			return "", err
 		}
 
-		if incoming.Type == eventType {
-			return incoming.Data.TxID, nil
+		if incoming.Type == spi.EventType(eventType) {
+			return incoming.TransactionID, nil
 		}
 
 		i++


### PR DESCRIPTION
Add optional fields to event and adjust sending and receiving events. Transaction ID has been moved from data payload to event level.

Closes #970

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>