### PR TITLE
chore: Configure event topics

### DIFF
--- a/cmd/vc-rest/startcmd/params.go
+++ b/cmd/vc-rest/startcmd/params.go
@@ -17,6 +17,7 @@ import (
 	"github.com/trustbloc/logutil-go/pkg/log"
 
 	"github.com/trustbloc/vcs/cmd/common"
+	"github.com/trustbloc/vcs/pkg/event/spi"
 	"github.com/trustbloc/vcs/pkg/kms"
 	profilereader "github.com/trustbloc/vcs/pkg/profile/reader"
 )
@@ -198,6 +199,14 @@ const (
 	requestObjectRepositoryS3RegionEnvKey    = "REQUEST_OBJECT_REPOSITORY_S3_REGION"
 	requestObjectRepositoryS3RegionFlagUsage = "request-object S3 Region"
 
+	issuerTopicFlagName  = "issuer-event-topic"
+	issuerTopicEnvKey    = "VC_REST_ISSUER_EVENT_TOPIC"
+	issuerTopicFlagUsage = "The name of the issuer event topic. " + commonEnvVarUsageText + issuerTopicEnvKey
+
+	verifierTopicFlagName  = "verifier-event-topic"
+	verifierTopicEnvKey    = "VC_REST_VERIFIER_EVENT_TOPIC"
+	verifierTopicFlagUsage = "The name of the verifier event topic. " + commonEnvVarUsageText + verifierTopicEnvKey
+
 	didMethodVeres   = "v1"
 	didMethodElement = "elem"
 	didMethodSov     = "sov"
@@ -233,6 +242,8 @@ type startupParameters struct {
 	requestObjectRepositoryType     string
 	requestObjectRepositoryS3Bucket string
 	requestObjectRepositoryS3Region string
+	issuerEventTopic                string
+	verifierEventTopic              string
 }
 
 type prometheusMetricsProviderParams struct {
@@ -373,6 +384,16 @@ func getStartupParameters(cmd *cobra.Command) (*startupParameters, error) {
 		requestObjectRepositoryS3RegionEnvKey,
 	)
 
+	issuerTopic := cmdutils.GetUserSetOptionalVarFromString(cmd, issuerTopicFlagName, issuerTopicEnvKey)
+	if issuerTopic == "" {
+		issuerTopic = spi.IssuerEventTopic
+	}
+
+	verifierTopic := cmdutils.GetUserSetOptionalVarFromString(cmd, verifierTopicFlagName, verifierTopicEnvKey)
+	if verifierTopic == "" {
+		verifierTopic = spi.VerifierEventTopic
+	}
+
 	return &startupParameters{
 		hostURL:                         hostURL,
 		hostURLExternal:                 hostURLExternal,
@@ -396,6 +417,8 @@ func getStartupParameters(cmd *cobra.Command) (*startupParameters, error) {
 		requestObjectRepositoryType:     requestObjectRepositoryType,
 		requestObjectRepositoryS3Bucket: requestObjectRepositoryS3Bucket,
 		requestObjectRepositoryS3Region: requestObjectRepositoryS3Region,
+		issuerEventTopic:                issuerTopic,
+		verifierEventTopic:              verifierTopic,
 	}, nil
 }
 
@@ -636,6 +659,9 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().String(requestObjectRepositoryTypeFlagName, "", requestObjectRepositoryTypeFlagUsage)
 	startCmd.Flags().String(requestObjectRepositoryS3BucketFlagName, "", requestObjectRepositoryS3BucketFlagUsage)
 	startCmd.Flags().String(requestObjectRepositoryS3RegionFlagName, "", requestObjectRepositoryS3RegionFlagUsage)
+
+	startCmd.Flags().StringP(issuerTopicFlagName, "", "", issuerTopicFlagUsage)
+	startCmd.Flags().StringP(verifierTopicFlagName, "", "", verifierTopicFlagUsage)
 
 	profilereader.AddFlags(startCmd)
 }

--- a/cmd/vc-rest/startcmd/start_test.go
+++ b/cmd/vc-rest/startcmd/start_test.go
@@ -238,6 +238,8 @@ func TestStartCmdValidArgs(t *testing.T) {
 		"--" + oAuthClientsFilePathFlagName, oauthClientsFile.Name(),
 		"--" + databaseURLFlagName, mongoDBConnString,
 		"--" + devModeFlagName, "true",
+		"--" + issuerTopicFlagName, "dev1-vcs-issuer",
+		"--" + verifierTopicFlagName, "dev1-vcs-verifier",
 	}
 	startCmd.SetArgs(args)
 

--- a/component/event/go.mod
+++ b/component/event/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/samber/lo v1.37.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
+	github.com/trustbloc/cmdutil-go v0.0.0-20221125151303-09d42adcc811
 	github.com/trustbloc/logutil-go v0.0.0-20221124174025-c46110e3ea42
 	github.com/trustbloc/vcs v0.0.0
 )

--- a/component/event/go.sum
+++ b/component/event/go.sum
@@ -29,6 +29,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/trustbloc/cmdutil-go v0.0.0-20221125151303-09d42adcc811 h1:0e1d1w9o662+e7ZnJvRYJH8yblcBXngme8qbsjTvhQc=
+github.com/trustbloc/cmdutil-go v0.0.0-20221125151303-09d42adcc811/go.mod h1:o/v7C1z6d/5UrjaC6GAUc1hk0XVuE3M4tpyvsMMUw5k=
 github.com/trustbloc/logutil-go v0.0.0-20221124174025-c46110e3ea42 h1:Mzg9wvEoUIWPoI/GHz3YlVbd4nKWeSPGc6+3l95eOZU=
 github.com/trustbloc/logutil-go v0.0.0-20221124174025-c46110e3ea42/go.mod h1:HRaXVV1caceumbDBwLO3ByiCcAc18KwrNvZ7JQBvDIQ=
 github.com/trustbloc/orb v1.0.0-rc4.0.20221129223433-07e05f2f6e0a h1:hTNcFcgr6cGzQAqQMOzenV+ZRp3dqTjaq2KQzvjqRXM=

--- a/component/oidc/vp/requestobjectstore.go
+++ b/component/oidc/vp/requestobjectstore.go
@@ -29,8 +29,9 @@ type eventService interface {
 }
 
 type RequestObjectStore struct {
-	repo     requestObjectStoreRepository
-	eventSvc eventService
+	repo       requestObjectStoreRepository
+	eventSvc   eventService
+	eventTopic string
 
 	selfURI string
 }
@@ -38,12 +39,13 @@ type RequestObjectStore struct {
 func NewRequestObjectStore(
 	repo requestObjectStoreRepository,
 	eventSvc eventService,
-	selfURI string,
+	selfURI, eventTopic string,
 ) *RequestObjectStore {
 	return &RequestObjectStore{
-		repo:     repo,
-		eventSvc: eventSvc,
-		selfURI:  selfURI,
+		repo:       repo,
+		eventSvc:   eventSvc,
+		selfURI:    selfURI,
+		eventTopic: eventTopic,
 	}
 }
 
@@ -84,7 +86,7 @@ func (s *RequestObjectStore) Get(ctx context.Context, id string) (*requestobject
 		return nil, err
 	}
 
-	err = s.eventSvc.Publish(spi.VerifierEventTopic, result.AccessRequestObjectEvent)
+	err = s.eventSvc.Publish(s.eventTopic, result.AccessRequestObjectEvent)
 	if err != nil {
 		return nil, err
 	}

--- a/component/oidc/vp/requestobjectstore_test.go
+++ b/component/oidc/vp/requestobjectstore_test.go
@@ -47,7 +47,7 @@ func TestRequestObjectStore(t *testing.T) {
 
 		eventSvc := NewMockEventService(gomock.NewController(t))
 
-		store := NewRequestObjectStore(repo, eventSvc, uri)
+		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 
 		finalURI, err := store.Publish(context.TODO(), string(dataBytes), &spi.Event{})
 
@@ -71,7 +71,7 @@ func TestRequestObjectStore(t *testing.T) {
 
 		eventSvc := NewMockEventService(gomock.NewController(t))
 
-		store := NewRequestObjectStore(repo, eventSvc, uri)
+		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 
 		finalURI, err := store.Publish(context.TODO(), string(dataBytes), &spi.Event{})
 
@@ -88,7 +88,7 @@ func TestRequestObjectStore(t *testing.T) {
 
 		eventSvc := NewMockEventService(gomock.NewController(t))
 
-		store := NewRequestObjectStore(repo, eventSvc, uri)
+		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 
 		finalURI, err := store.Publish(context.TODO(), string(dataBytes), &spi.Event{})
 		assert.Empty(t, finalURI)
@@ -105,7 +105,7 @@ func TestRequestObjectStore(t *testing.T) {
 		eventSvc := NewMockEventService(gomock.NewController(t))
 		eventSvc.EXPECT().Publish(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
-		store := NewRequestObjectStore(repo, eventSvc, uri)
+		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 
 		resp, err := store.Get(context.TODO(), id)
 
@@ -120,7 +120,7 @@ func TestRequestObjectStore(t *testing.T) {
 
 		eventSvc := NewMockEventService(gomock.NewController(t))
 
-		store := NewRequestObjectStore(repo, eventSvc, uri)
+		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 
 		_, err := store.Get(context.TODO(), id)
 
@@ -137,7 +137,7 @@ func TestRequestObjectStore(t *testing.T) {
 		eventSvc := NewMockEventService(gomock.NewController(t))
 		eventSvc.EXPECT().Publish(gomock.Any(), gomock.Any()).Times(1).Return(errors.New("publish failed"))
 
-		store := NewRequestObjectStore(repo, eventSvc, uri)
+		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 
 		_, err := store.Get(context.TODO(), id)
 
@@ -171,7 +171,7 @@ func TestDelete(t *testing.T) {
 
 			eventSvc := NewMockEventService(gomock.NewController(t))
 
-			store := NewRequestObjectStore(repo, eventSvc, "")
+			store := NewRequestObjectStore(repo, eventSvc, "", spi.VerifierEventTopic)
 
 			assert.NoError(t, store.Remove(context.TODO(), testCase.path))
 		})

--- a/pkg/service/oidc4ci/oidc4ci_service.go
+++ b/pkg/service/oidc4ci/oidc4ci_service.go
@@ -99,6 +99,7 @@ type Config struct {
 	HTTPClient          httpClient
 	EventService        eventService
 	PinGenerator        pinGenerator
+	EventTopic          string
 }
 
 // Service implements VCS credential interaction API for OIDC credential issuance.
@@ -109,6 +110,7 @@ type Service struct {
 	oAuth2Client        oAuth2Client
 	httpClient          httpClient
 	eventSvc            eventService
+	eventTopic          string
 	pinGenerator        pinGenerator
 }
 
@@ -121,6 +123,7 @@ func NewService(config *Config) (*Service, error) {
 		oAuth2Client:        config.OAuth2Client,
 		httpClient:          config.HTTPClient,
 		eventSvc:            config.EventService,
+		eventTopic:          config.EventTopic,
 		pinGenerator:        config.PinGenerator,
 	}, nil
 }
@@ -411,7 +414,7 @@ func (s *Service) sendEventWithError(tx *Transaction, eventType spi.EventType, e
 		return err
 	}
 
-	return s.eventSvc.Publish(spi.IssuerEventTopic, event)
+	return s.eventSvc.Publish(s.eventTopic, event)
 }
 
 func (s *Service) sendFailedEvent(tx *Transaction, err error) {

--- a/pkg/service/oidc4ci/oidc4ci_service_exchange_code_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_exchange_code_test.go
@@ -31,6 +31,7 @@ func TestExchangeCode(t *testing.T) {
 		OAuth2Client:     oauth2Client,
 		HTTPClient:       &http.Client{},
 		EventService:     eventMock,
+		EventTopic:       spi.IssuerEventTopic,
 	})
 	assert.NoError(t, err)
 
@@ -104,6 +105,7 @@ func TestExchangeCodeIssuerError(t *testing.T) {
 		OAuth2Client:     oauth2Client,
 		HTTPClient:       &http.Client{},
 		EventService:     eventMock,
+		EventTopic:       spi.IssuerEventTopic,
 	})
 	assert.NoError(t, err)
 
@@ -142,6 +144,7 @@ func TestExchangeCodeStoreUpdateErr(t *testing.T) {
 		OAuth2Client:     oauth2Client,
 		HTTPClient:       &http.Client{},
 		EventService:     eventMock,
+		EventTopic:       spi.IssuerEventTopic,
 	})
 	assert.NoError(t, err)
 
@@ -187,6 +190,7 @@ func TestExchangeCodeInvalidState(t *testing.T) {
 	srv, err := oidc4ci.NewService(&oidc4ci.Config{
 		TransactionStore: store,
 		EventService:     eventMock,
+		EventTopic:       spi.IssuerEventTopic,
 	})
 	assert.NoError(t, err)
 
@@ -220,6 +224,7 @@ func TestExchangeCodePublishError(t *testing.T) {
 		OAuth2Client:     oauth2Client,
 		HTTPClient:       &http.Client{},
 		EventService:     eventMock,
+		EventTopic:       spi.IssuerEventTopic,
 	})
 	assert.NoError(t, err)
 

--- a/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance_test.go
@@ -659,6 +659,7 @@ func TestService_InitiateIssuance(t *testing.T) {
 				WellKnownService:    mockWellKnownService,
 				IssuerVCSPublicHost: issuerVCSPublicHost,
 				EventService:        eventService,
+				EventTopic:          spi.IssuerEventTopic,
 				PinGenerator:        pinGenerator,
 			})
 			require.NoError(t, err)

--- a/pkg/service/oidc4ci/oidc4ci_service_store_auth_code_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_store_auth_code_test.go
@@ -26,6 +26,7 @@ func TestStoreAuthCode(t *testing.T) {
 	srv, err := oidc4ci.NewService(&oidc4ci.Config{
 		TransactionStore: store,
 		EventService:     eventMock,
+		EventTopic:       spi.IssuerEventTopic,
 	})
 	assert.NoError(t, err)
 

--- a/pkg/service/oidc4ci/oidc4ci_service_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_test.go
@@ -489,6 +489,7 @@ func TestService_PrepareClaimDataAuthorizationRequest(t *testing.T) {
 			svc, err := oidc4ci.NewService(&oidc4ci.Config{
 				TransactionStore: mockTransactionStore,
 				EventService:     eventMock,
+				EventTopic:       spi.IssuerEventTopic,
 			})
 			require.NoError(t, err)
 
@@ -507,6 +508,7 @@ func TestValidatePreAuthCode(t *testing.T) {
 		srv, err := oidc4ci.NewService(&oidc4ci.Config{
 			TransactionStore: storeMock,
 			EventService:     eventService,
+			EventTopic:       spi.IssuerEventTopic,
 			PinGenerator:     pinGenerator,
 		})
 		assert.NoError(t, err)
@@ -541,6 +543,7 @@ func TestValidatePreAuthCode(t *testing.T) {
 		srv, err := oidc4ci.NewService(&oidc4ci.Config{
 			TransactionStore: storeMock,
 			EventService:     eventMock,
+			EventTopic:       spi.IssuerEventTopic,
 		})
 		assert.NoError(t, err)
 
@@ -573,6 +576,7 @@ func TestValidatePreAuthCode(t *testing.T) {
 		srv, err := oidc4ci.NewService(&oidc4ci.Config{
 			TransactionStore: storeMock,
 			EventService:     eventMock,
+			EventTopic:       spi.IssuerEventTopic,
 		})
 		assert.NoError(t, err)
 
@@ -1039,6 +1043,7 @@ func TestService_PrepareCredential(t *testing.T) {
 				TransactionStore: mockTransactionStore,
 				HTTPClient:       mockHTTPClient,
 				EventService:     eventMock,
+				EventTopic:       spi.IssuerEventTopic,
 			})
 			require.NoError(t, err)
 

--- a/pkg/service/oidc4vp/oidc4vp_service.go
+++ b/pkg/service/oidc4vp/oidc4vp_service.go
@@ -104,6 +104,7 @@ type Config struct {
 	DocumentLoader           ld.DocumentLoader
 	ProfileService           profileService
 	EventSvc                 eventService
+	EventTopic               string
 	PresentationVerifier     presentationVerifier
 	PublicKeyFetcher         verifiable.PublicKeyFetcher
 
@@ -130,6 +131,7 @@ type metricsProvider interface {
 
 type Service struct {
 	eventSvc                 eventService
+	eventTopic               string
 	transactionManager       transactionManager
 	requestObjectPublicStore requestObjectPublicStore
 	kmsRegistry              kmsRegistry
@@ -169,6 +171,7 @@ func NewService(cfg *Config) *Service {
 
 	return &Service{
 		eventSvc:                 cfg.EventSvc,
+		eventTopic:               cfg.EventTopic,
 		transactionManager:       cfg.TransactionManager,
 		requestObjectPublicStore: cfg.RequestObjectPublicStore,
 		kmsRegistry:              cfg.KMSRegistry,
@@ -214,7 +217,7 @@ func (s *Service) sendEventWithError(tx *Transaction, profile *profileapi.Verifi
 		return err
 	}
 
-	return s.eventSvc.Publish(spi.VerifierEventTopic, event)
+	return s.eventSvc.Publish(s.eventTopic, event)
 }
 
 func (s *Service) sendFailedEvent(tx *Transaction, profile *profileapi.Verifier, err error) {

--- a/pkg/service/oidc4vp/oidc4vp_service_test.go
+++ b/pkg/service/oidc4vp/oidc4vp_service_test.go
@@ -80,6 +80,7 @@ func TestService_InitiateOidcInteraction(t *testing.T) {
 
 	s := oidc4vp.NewService(&oidc4vp.Config{
 		EventSvc:                 &mockEvent{},
+		EventTopic:               spi.VerifierEventTopic,
 		TransactionManager:       txManager,
 		RequestObjectPublicStore: requestObjectPublicStore,
 		KMSRegistry:              kmsRegistry,
@@ -131,6 +132,7 @@ func TestService_InitiateOidcInteraction(t *testing.T) {
 
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:                 &mockEvent{},
+			EventTopic:               spi.VerifierEventTopic,
 			TransactionManager:       txManagerErr,
 			RequestObjectPublicStore: requestObjectPublicStore,
 			KMSRegistry:              kmsRegistry,
@@ -155,6 +157,7 @@ func TestService_InitiateOidcInteraction(t *testing.T) {
 
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:                 &mockEvent{},
+			EventTopic:               spi.VerifierEventTopic,
 			TransactionManager:       txManager,
 			RequestObjectPublicStore: requestObjectPublicStoreErr,
 			KMSRegistry:              kmsRegistry,
@@ -178,6 +181,7 @@ func TestService_InitiateOidcInteraction(t *testing.T) {
 
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:                 &mockEvent{},
+			EventTopic:               spi.VerifierEventTopic,
 			TransactionManager:       txManager,
 			RequestObjectPublicStore: requestObjectPublicStore,
 			KMSRegistry:              kmsRegistry,
@@ -228,6 +232,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 
 	s := oidc4vp.NewService(&oidc4vp.Config{
 		EventSvc:             &mockEvent{},
+		EventTopic:           spi.VerifierEventTopic,
 		TransactionManager:   txManager,
 		PresentationVerifier: presentationVerifier,
 		ProfileService:       profileService,
@@ -285,6 +290,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:             &mockEvent{},
+			EventTopic:           spi.VerifierEventTopic,
 			TransactionManager:   errTxManager,
 			PresentationVerifier: presentationVerifier,
 			ProfileService:       profileService,
@@ -319,6 +325,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:             &mockEvent{},
+			EventTopic:           spi.VerifierEventTopic,
 			TransactionManager:   txManager,
 			PresentationVerifier: presentationVerifier,
 			ProfileService:       errProfileService,
@@ -341,6 +348,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 			Return(nil, errors.New("verification failed"))
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:             &mockEvent{},
+			EventTopic:           spi.VerifierEventTopic,
 			TransactionManager:   txManager,
 			PresentationVerifier: errPresentationVerifier,
 			ProfileService:       profileService,
@@ -379,6 +387,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:             &mockEvent{},
+			EventTopic:           spi.VerifierEventTopic,
 			TransactionManager:   errTxManager,
 			PresentationVerifier: presentationVerifier,
 			ProfileService:       profileService,


### PR DESCRIPTION
The issuer and verifier event topic names are now configurable. By default they are 'vcs-issuer' and 'vcs-verifier' respectively.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>