### PR TITLE
chore: update AFGO version

### DIFF
--- a/cmd/vc-rest/go.mod
+++ b/cmd/vc-rest/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/deepmap/oapi-codegen v1.11.0
 	github.com/google/uuid v1.3.0
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/jwk v0.0.0-20221213152252-f0c83a5a922c
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221213152252-f0c83a5a922c
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc5.0.20221213152252-f0c83a5a922c

--- a/cmd/vc-rest/go.sum
+++ b/cmd/vc-rest/go.sum
@@ -562,8 +562,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 h1:kEI53D7bDfEJVTfkSTcB58qsDPpAB+GoVYACh5Zok9Y=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb h1:VyCKo5A6iKy17vp5lZampMMyNe6exNiSBY1ByMX4R/0=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1 h1:J17kEzMu0cA2xsgC0VcZiKu9ivV0/WMMmeCW7UrfQ1Y=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1/go.mod h1:q8qjsQpYo7AYG0pqQg1zgEoIVc+Hrpf5S0WciiwPDQA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149 h1:8ja6Vnp5EUsh8Oe4mI8ZNwpJtiM7c87X/b9sO/hEFiY=

--- a/component/credentialstatus/go.mod
+++ b/component/credentialstatus/go.mod
@@ -9,7 +9,7 @@ go 1.19
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221201213446-c4c1e76daa49
 	github.com/piprate/json-gold v0.5.0
 	github.com/spf13/cobra v1.6.1

--- a/component/credentialstatus/go.sum
+++ b/component/credentialstatus/go.sum
@@ -494,8 +494,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 h1:kEI53D7bDfEJVTfkSTcB58qsDPpAB+GoVYACh5Zok9Y=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb h1:VyCKo5A6iKy17vp5lZampMMyNe6exNiSBY1ByMX4R/0=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149 h1:8ja6Vnp5EUsh8Oe4mI8ZNwpJtiM7c87X/b9sO/hEFiY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221201213446-c4c1e76daa49 h1:MbWVC1HQEAn5yw5DLs4D7kdcM06y6ZiN4r3ZtvDzxWE=

--- a/component/event/go.mod
+++ b/component/event/go.mod
@@ -16,7 +16,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 // indirect
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/component/event/go.sum
+++ b/component/event/go.sum
@@ -4,8 +4,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 h1:kEI53D7bDfEJVTfkSTcB58qsDPpAB+GoVYACh5Zok9Y=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb h1:VyCKo5A6iKy17vp5lZampMMyNe6exNiSBY1ByMX4R/0=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=

--- a/component/profile/reader/file/go.mod
+++ b/component/profile/reader/file/go.mod
@@ -6,7 +6,7 @@ module github.com/trustbloc/vcs/component/profile/reader/file
 go 1.19
 
 require (
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/jwk v0.0.0-20221213152252-f0c83a5a922c
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221213152252-f0c83a5a922c
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc5.0.20221213152252-f0c83a5a922c

--- a/component/profile/reader/file/go.sum
+++ b/component/profile/reader/file/go.sum
@@ -494,8 +494,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 h1:kEI53D7bDfEJVTfkSTcB58qsDPpAB+GoVYACh5Zok9Y=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb h1:VyCKo5A6iKy17vp5lZampMMyNe6exNiSBY1ByMX4R/0=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149 h1:8ja6Vnp5EUsh8Oe4mI8ZNwpJtiM7c87X/b9sO/hEFiY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/jwk v0.0.0-20221213152252-f0c83a5a922c h1:74wqdvAd3S9BuKolIV0obbG8PhbChtF9sQrE/ov2se0=

--- a/component/wallet-cli/go.mod
+++ b/component/wallet-cli/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cli/browser v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/henvic/httpretty v0.1.0
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221201213446-c4c1e76daa49
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc5.0.20221201213446-c4c1e76daa49

--- a/component/wallet-cli/go.sum
+++ b/component/wallet-cli/go.sum
@@ -527,8 +527,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 h1:kEI53D7bDfEJVTfkSTcB58qsDPpAB+GoVYACh5Zok9Y=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb h1:VyCKo5A6iKy17vp5lZampMMyNe6exNiSBY1ByMX4R/0=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149 h1:8ja6Vnp5EUsh8Oe4mI8ZNwpJtiM7c87X/b9sO/hEFiY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221201213446-c4c1e76daa49 h1:MbWVC1HQEAn5yw5DLs4D7kdcM06y6ZiN4r3ZtvDzxWE=

--- a/component/wallet-cli/pkg/walletrunner/wallet_runner_oidc4vp.go
+++ b/component/wallet-cli/pkg/walletrunner/wallet_runner_oidc4vp.go
@@ -264,27 +264,6 @@ func (e *VPFlowExecutor) QueryCredentialFromWallet() error {
 
 	e.requestPresentation = vps[0]
 
-	for _, c := range vps[0].Credentials() {
-		credential, ok := c.(*verifiable.Credential)
-		if !ok {
-			continue
-		}
-
-		//TODO: this condition must be gone once AFGO will properly support Marshal/Unmarshal SDJWT credential.
-		if credential.JWT != "" && len(credential.SDJWTDisclosures) > 0 {
-			// Creating Combined Format for Presentation from credential assuming that
-			// wallet.Query() returned only those disclosures, that must be disclosed according to query.
-			sdjwt, err := credential.MarshalWithDisclosure(verifiable.DiscloseAll())
-			if err != nil {
-				continue
-			}
-
-			sdjwt = strings.TrimSuffix(sdjwt, "~")
-
-			credential.JWT = sdjwt
-		}
-	}
-
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/tink/go v1.7.0
 	github.com/google/uuid v1.3.0
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20220330151152-6bbd64bde42e

--- a/go.sum
+++ b/go.sum
@@ -563,6 +563,8 @@ github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 h1:kEI53D7bDfEJVTfkSTcB58qsDPpAB+GoVYACh5Zok9Y=
 github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb h1:VyCKo5A6iKy17vp5lZampMMyNe6exNiSBY1ByMX4R/0=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1 h1:J17kEzMu0cA2xsgC0VcZiKu9ivV0/WMMmeCW7UrfQ1Y=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220428163625-96d8261511e1/go.mod h1:q8qjsQpYo7AYG0pqQg1zgEoIVc+Hrpf5S0WciiwPDQA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149 h1:8ja6Vnp5EUsh8Oe4mI8ZNwpJtiM7c87X/b9sO/hEFiY=

--- a/pkg/storage/mongodb/oidc4vptxstore/oidc4vp_tx_store.go
+++ b/pkg/storage/mongodb/oidc4vptxstore/oidc4vp_tx_store.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
@@ -118,19 +117,6 @@ func (p *TxStore) Update(update oidc4vp.TransactionUpdate) error {
 
 	if update.ReceivedClaims != nil {
 		for key, cred := range update.ReceivedClaims.Credentials {
-			//TODO: this condition must be gone once AFGO will properly support Marshal/Unmarshal SDJWT credential.
-			if cred.JWT != "" && len(cred.SDJWTDisclosures) > 0 {
-				var sdjwt string
-				sdjwt, err = cred.MarshalWithDisclosure(verifiable.DiscloseAll())
-				if err != nil {
-					continue
-				}
-
-				sdjwt = strings.TrimSuffix(sdjwt, "~")
-
-				cred.JWT = sdjwt
-			}
-
 			receivedClaims[key], err = json.Marshal(cred)
 			if err != nil {
 				return fmt.Errorf("update tx doc: encode received claims %w", err)

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/greenpau/go-calculator v1.0.1
-	github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8
+	github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc5.0.20221201213446-c4c1e76daa49
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20221025204933-b807371b6f1e

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -560,8 +560,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8 h1:kEI53D7bDfEJVTfkSTcB58qsDPpAB+GoVYACh5Zok9Y=
-github.com/hyperledger/aries-framework-go v0.1.9-0.20230130162404-f04236427ab8/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb h1:VyCKo5A6iKy17vp5lZampMMyNe6exNiSBY1ByMX4R/0=
+github.com/hyperledger/aries-framework-go v0.1.9-0.20230131173032-b4e5124106cb/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149 h1:8ja6Vnp5EUsh8Oe4mI8ZNwpJtiM7c87X/b9sO/hEFiY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220728172020-0a8903e45149/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221201213446-c4c1e76daa49 h1:MbWVC1HQEAn5yw5DLs4D7kdcM06y6ZiN4r3ZtvDzxWE=

--- a/test/bdd/pkg/v1/oidc4vp/vpflow_executor.go
+++ b/test/bdd/pkg/v1/oidc4vp/vpflow_executor.go
@@ -127,27 +127,6 @@ func (e *VPFlowExecutor) queryCredentialFromWallet() error {
 		return fmt.Errorf("query vc using presentation definition: %w", err)
 	}
 
-	for _, c := range vps[0].Credentials() {
-		credential, ok := c.(*verifiable.Credential)
-		if !ok {
-			continue
-		}
-
-		//TODO: this condition must be gone once AFGO will properly support Marshal/Unmarshal SDJWT credential.
-		if credential.JWT != "" && len(credential.SDJWTDisclosures) > 0 {
-			// Creating Combined Format for Presentation from credential assuming that
-			// wallet.Query() returned only those disclosures, that must be disclosed according to query.
-			sdjwt, err := credential.MarshalWithDisclosure(verifiable.DiscloseAll())
-			if err != nil {
-				continue
-			}
-
-			sdjwt = strings.TrimSuffix(sdjwt, "~")
-
-			credential.JWT = sdjwt
-		}
-	}
-
 	e.requestPresentation = vps[0]
 
 	return nil


### PR DESCRIPTION
Update VCS to use latest AFGO version.
Includes:
- Fixed bug with Marshaling/Unmarshaling SDJWT VC so all redundant workarounds are removed.  

Signed-off-by: Mykhailo Sizov <mykhailo.sizov@securekey.com>