### PR TITLE
refactor: Added context to event Publish signature

### DIFF
--- a/component/event/bus.go
+++ b/component/event/bus.go
@@ -109,7 +109,7 @@ func (b *Bus) stop() {
 
 // Subscribe subscribes to a topic and returns the Go channel over which messages
 // are sent. The returned channel will be closed when Close() is called on this struct.
-func (b *Bus) Subscribe(_ context.Context, topic string, _ ...spi.Option) (<-chan *spi.Event, error) {
+func (b *Bus) Subscribe(_ context.Context, topic string) (<-chan *spi.Event, error) {
 	if b.State() != lifecycle.StateStarted {
 		return nil, lifecycle.ErrNotStarted
 	}
@@ -129,7 +129,7 @@ func (b *Bus) Subscribe(_ context.Context, topic string, _ ...spi.Option) (<-cha
 // Publish publishes the given messages to the given topic. This function returns
 // immediately after sending the messages to the Go channel(s), although it will
 // block if the concurrency limit (defined by Config.Concurrency) has been reached.
-func (b *Bus) Publish(topic string, messages ...*spi.Event) error {
+func (b *Bus) Publish(_ context.Context, topic string, messages ...*spi.Event) error {
 	if b.State() != lifecycle.StateStarted {
 		return lifecycle.ErrNotStarted
 	}
@@ -140,11 +140,6 @@ func (b *Bus) Publish(topic string, messages ...*spi.Event) error {
 	}
 
 	return nil
-}
-
-// PublishWithOpts simply calls Publish since options are not supported.
-func (b *Bus) PublishWithOpts(topic string, msg *spi.Event, _ ...spi.Option) error {
-	return b.Publish(topic, msg)
 }
 
 func (b *Bus) processMessages() {

--- a/component/event/bus_test.go
+++ b/component/event/bus_test.go
@@ -49,7 +49,7 @@ func TestEventBus_Publish(t *testing.T) {
 
 		msg := spi.NewEventWithPayload(uuid, sourceURL, eventType, []byte(jsonMsg))
 
-		require.NoError(t, eb.Publish(topic, msg))
+		require.NoError(t, eb.Publish(context.Background(), topic, msg))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -64,7 +64,7 @@ func TestEventBus_Publish(t *testing.T) {
 	t.Run("success - no subscribers", func(t *testing.T) {
 		msg := spi.NewEventWithPayload(uuid, sourceURL, eventType, []byte("{}"))
 
-		require.NoError(t, eb.PublishWithOpts("no-subscribers-topic", msg, spi.WithDeliveryDelay(5*time.Second)))
+		require.NoError(t, eb.Publish(context.TODO(), "no-subscribers-topic", msg))
 
 		time.Sleep(1000 * time.Millisecond)
 	})
@@ -88,7 +88,7 @@ func TestEventBus_Error(t *testing.T) {
 		require.NotNil(t, eb)
 		require.NoError(t, eb.Close())
 
-		err := eb.Publish(topic, spi.NewEventWithPayload(uuid, sourceURL, eventType, []byte(jsonMsg)))
+		err := eb.Publish(context.Background(), topic, spi.NewEventWithPayload(uuid, sourceURL, eventType, []byte(jsonMsg)))
 		require.True(t, errors.Is(err, lifecycle.ErrNotStarted))
 	})
 }
@@ -118,7 +118,7 @@ func TestEventBus_Close(t *testing.T) {
 		for i := 0; i < 250; i++ {
 			msg := spi.NewEventWithPayload(fmt.Sprintf("%s-%d", uuid, i), sourceURL, eventType, []byte(jsonMsg))
 
-			if err := eb.PublishWithOpts(topic, msg); err != nil {
+			if err := eb.Publish(context.TODO(), topic, msg); err != nil {
 				if errors.Is(err, lifecycle.ErrNotStarted) {
 					return
 				}

--- a/component/event/mocks/publisher.gen.go
+++ b/component/event/mocks/publisher.gen.go
@@ -2,17 +2,19 @@
 package mocks
 
 import (
+	"context"
 	"sync"
 
 	"github.com/trustbloc/vcs/pkg/event/spi"
 )
 
 type EventPublisher struct {
-	PublishStub        func(string, ...*spi.Event) error
+	PublishStub        func(context.Context, string, ...*spi.Event) error
 	publishMutex       sync.RWMutex
 	publishArgsForCall []struct {
-		arg1 string
-		arg2 []*spi.Event
+		arg1 context.Context
+		arg2 string
+		arg3 []*spi.Event
 	}
 	publishReturns struct {
 		result1 error
@@ -24,22 +26,24 @@ type EventPublisher struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *EventPublisher) Publish(arg1 string, arg2 ...*spi.Event) error {
+func (fake *EventPublisher) Publish(arg1 context.Context, arg2 string, arg3 ...*spi.Event) error {
 	fake.publishMutex.Lock()
 	ret, specificReturn := fake.publishReturnsOnCall[len(fake.publishArgsForCall)]
 	fake.publishArgsForCall = append(fake.publishArgsForCall, struct {
-		arg1 string
-		arg2 []*spi.Event
-	}{arg1, arg2})
-	fake.recordInvocation("Publish", []interface{}{arg1, arg2})
+		arg1 context.Context
+		arg2 string
+		arg3 []*spi.Event
+	}{arg1, arg2, arg3})
+	stub := fake.PublishStub
+	fakeReturns := fake.publishReturns
+	fake.recordInvocation("Publish", []interface{}{arg1, arg2, arg3})
 	fake.publishMutex.Unlock()
-	if fake.PublishStub != nil {
-		return fake.PublishStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.publishReturns
 	return fakeReturns.result1
 }
 
@@ -49,17 +53,17 @@ func (fake *EventPublisher) PublishCallCount() int {
 	return len(fake.publishArgsForCall)
 }
 
-func (fake *EventPublisher) PublishCalls(stub func(string, ...*spi.Event) error) {
+func (fake *EventPublisher) PublishCalls(stub func(context.Context, string, ...*spi.Event) error) {
 	fake.publishMutex.Lock()
 	defer fake.publishMutex.Unlock()
 	fake.PublishStub = stub
 }
 
-func (fake *EventPublisher) PublishArgsForCall(i int) (string, []*spi.Event) {
+func (fake *EventPublisher) PublishArgsForCall(i int) (context.Context, string, []*spi.Event) {
 	fake.publishMutex.RLock()
 	defer fake.publishMutex.RUnlock()
 	argsForCall := fake.publishArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *EventPublisher) PublishReturns(result1 error) {

--- a/component/event/mocks/subscriber.gen.go
+++ b/component/event/mocks/subscriber.gen.go
@@ -27,22 +27,23 @@ type EventSubscriber struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *EventSubscriber) Subscribe(arg1 context.Context, arg2 string, _ ...spi.Option) (<-chan *spi.Event, error) {
+func (fake *EventSubscriber) Subscribe(arg1 context.Context, arg2 string) (<-chan *spi.Event, error) {
 	fake.subscribeMutex.Lock()
 	ret, specificReturn := fake.subscribeReturnsOnCall[len(fake.subscribeArgsForCall)]
 	fake.subscribeArgsForCall = append(fake.subscribeArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SubscribeStub
+	fakeReturns := fake.subscribeReturns
 	fake.recordInvocation("Subscribe", []interface{}{arg1, arg2})
 	fake.subscribeMutex.Unlock()
-	if fake.SubscribeStub != nil {
-		return fake.SubscribeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.subscribeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/component/event/publisher.go
+++ b/component/event/publisher.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package event
 
 import (
+	"context"
+
 	"github.com/trustbloc/vcs/pkg/event/spi"
 )
 
@@ -18,13 +20,13 @@ func NewEventPublisher(pub eventPublisher) *Publisher {
 }
 
 type eventPublisher interface {
-	Publish(topic string, messages ...*spi.Event) error
+	Publish(ctx context.Context, topic string, events ...*spi.Event) error
 }
 
 type Publisher struct {
 	publisher eventPublisher
 }
 
-func (p *Publisher) Publish(topic string, events ...*spi.Event) error {
-	return p.publisher.Publish(topic, events...)
+func (p *Publisher) Publish(ctx context.Context, topic string, events ...*spi.Event) error {
+	return p.publisher.Publish(ctx, topic, events...)
 }

--- a/component/event/publisher_test.go
+++ b/component/event/publisher_test.go
@@ -25,18 +25,23 @@ func TestEventPublisher(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		eventBus := NewEventBus(Config{})
 
-		ch1, err := eventBus.Subscribe(context.TODO(), topic)
+		ctx := context.TODO()
+
+		ch1, err := eventBus.Subscribe(ctx, topic)
 		require.NoError(t, err)
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(ctx, topic,
+			spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
 
-		_, err = eventBus.Subscribe(context.TODO(), topic)
+		_, err = eventBus.Subscribe(ctx, topic)
 		require.NoError(t, err)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-2", sourceURL, eventType, []byte(jsonMsg))))
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-3", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(ctx, topic,
+			spi.NewEventWithPayload("id-2", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(ctx, topic,
+			spi.NewEventWithPayload("id-3", sourceURL, eventType, []byte(jsonMsg))))
 
 		done := make(chan interface{})
 
@@ -63,7 +68,8 @@ func TestEventPublisher(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		err := publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg)))
+		err := publisher.Publish(context.TODO(), topic,
+			spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg)))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "publishing error")
 	})

--- a/component/event/subscriber.go
+++ b/component/event/subscriber.go
@@ -22,7 +22,7 @@ type (
 )
 
 type eventSubscriber interface {
-	Subscribe(ctx context.Context, topic string, _ ...spi.Option) (<-chan *spi.Event, error)
+	Subscribe(ctx context.Context, topic string) (<-chan *spi.Event, error)
 }
 
 // Subscriber implements an event subscriber.

--- a/component/event/subscriber_test.go
+++ b/component/event/subscriber_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package event
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -22,6 +23,8 @@ import (
 
 func TestEventSubscriber(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
+		ctx := context.TODO()
+
 		eventBus := NewEventBus(Config{})
 
 		subscriber, err := NewEventSubscriber(eventBus, topic, printEvent)
@@ -31,9 +34,12 @@ func TestEventSubscriber(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-2", sourceURL, eventType, []byte(jsonMsg))))
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-3", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(ctx, topic,
+			spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(ctx, topic,
+			spi.NewEventWithPayload("id-2", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(ctx, topic,
+			spi.NewEventWithPayload("id-3", sourceURL, eventType, []byte(jsonMsg))))
 
 		time.Sleep(time.Second)
 	})
@@ -48,7 +54,8 @@ func TestEventSubscriber(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(context.TODO(), topic,
+			spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
 
 		time.Sleep(time.Second)
 
@@ -67,7 +74,8 @@ func TestEventSubscriber(t *testing.T) {
 
 		publisher := NewEventPublisher(eventBus)
 
-		require.NoError(t, publisher.Publish(topic, spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
+		require.NoError(t, publisher.Publish(context.TODO(), topic,
+			spi.NewEventWithPayload("id-1", sourceURL, eventType, []byte(jsonMsg))))
 
 		time.Sleep(time.Second)
 	})

--- a/component/oidc/vp/requestobjectstore.go
+++ b/component/oidc/vp/requestobjectstore.go
@@ -25,7 +25,7 @@ type requestObjectStoreRepository interface {
 }
 
 type eventService interface {
-	Publish(topic string, messages ...*spi.Event) error
+	Publish(ctx context.Context, topic string, messages ...*spi.Event) error
 }
 
 type RequestObjectStore struct {
@@ -86,7 +86,7 @@ func (s *RequestObjectStore) Get(ctx context.Context, id string) (*requestobject
 		return nil, err
 	}
 
-	err = s.eventSvc.Publish(s.eventTopic, result.AccessRequestObjectEvent)
+	err = s.eventSvc.Publish(ctx, s.eventTopic, result.AccessRequestObjectEvent)
 	if err != nil {
 		return nil, err
 	}

--- a/component/oidc/vp/requestobjectstore_test.go
+++ b/component/oidc/vp/requestobjectstore_test.go
@@ -103,7 +103,7 @@ func TestRequestObjectStore(t *testing.T) {
 		}, nil)
 
 		eventSvc := NewMockEventService(gomock.NewController(t))
-		eventSvc.EXPECT().Publish(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		eventSvc.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 
@@ -135,7 +135,7 @@ func TestRequestObjectStore(t *testing.T) {
 		}, nil)
 
 		eventSvc := NewMockEventService(gomock.NewController(t))
-		eventSvc.EXPECT().Publish(gomock.Any(), gomock.Any()).Times(1).Return(errors.New("publish failed"))
+		eventSvc.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(errors.New("publish failed"))
 
 		store := NewRequestObjectStore(repo, eventSvc, uri, spi.VerifierEventTopic)
 

--- a/pkg/event/spi/spi.go
+++ b/pkg/event/spi/spi.go
@@ -118,27 +118,3 @@ func NewEvent(uuid string, source string, eventType EventType) *Event {
 		Time:        util.NewTime(now),
 	}
 }
-
-// Options contains publisher/subscriber options.
-type Options struct {
-	PoolSize      int
-	DeliveryDelay time.Duration
-}
-
-// Option specifies a publisher/subscriber option.
-type Option func(option *Options)
-
-// WithPool sets the pool size.
-func WithPool(size int) Option {
-	return func(option *Options) {
-		option.PoolSize = size
-	}
-}
-
-// WithDeliveryDelay sets the delivery delay.
-// Note: Not all message brokers support this option.
-func WithDeliveryDelay(delay time.Duration) Option {
-	return func(option *Options) {
-		option.DeliveryDelay = delay
-	}
-}

--- a/pkg/event/spi/spi_test.go
+++ b/pkg/event/spi/spi_test.go
@@ -8,7 +8,6 @@ package spi
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -22,14 +21,4 @@ func TestEvent(t *testing.T) {
 
 	eventCopy := event.Copy()
 	require.NotNil(t, eventCopy)
-}
-
-func TestOptions(t *testing.T) {
-	var opts []Option
-	opts = append(opts, WithDeliveryDelay(time.Second), WithPool(2))
-
-	var options Options
-	for _, opt := range opts {
-		opt(&options)
-	}
 }

--- a/pkg/restapi/v1/issuer/controller.go
+++ b/pkg/restapi/v1/issuer/controller.go
@@ -53,7 +53,7 @@ type profileService interface {
 }
 
 type eventService interface {
-	Publish(topic string, messages ...*spi.Event) error
+	Publish(ctx context.Context, topic string, messages ...*spi.Event) error
 }
 
 type issueCredentialService interface {

--- a/pkg/service/oidc4ci/oidc4ci_service_exchange_code.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_exchange_code.go
@@ -24,14 +24,14 @@ func (s *Service) ExchangeAuthorizationCode(ctx context.Context, opState string)
 
 	newState := TransactionStateIssuerOIDCAuthorizationDone
 	if err = s.validateStateTransition(tx.State, newState); err != nil {
-		s.sendFailedEvent(tx, err)
+		s.sendFailedEvent(ctx, tx, err)
 		return "", err
 	}
 	tx.State = newState
 
 	profile, err := s.profileService.GetProfile(tx.ProfileID)
 	if err != nil {
-		s.sendFailedEvent(tx, err)
+		s.sendFailedEvent(ctx, tx, err)
 		return "", err
 	}
 
@@ -47,18 +47,18 @@ func (s *Service) ExchangeAuthorizationCode(ctx context.Context, opState string)
 		Scopes:      tx.Scope,
 	}, tx.IssuerAuthCode, s.httpClient.(*http.Client)) // TODO: Fix this!
 	if err != nil {
-		s.sendFailedEvent(tx, err)
+		s.sendFailedEvent(ctx, tx, err)
 		return "", err
 	}
 
 	tx.IssuerToken = resp.AccessToken
 
 	if err = s.store.Update(ctx, tx); err != nil {
-		s.sendFailedEvent(tx, err)
+		s.sendFailedEvent(ctx, tx, err)
 		return "", err
 	}
 
-	if err = s.sendEvent(tx, spi.IssuerOIDCInteractionAuthorizationCodeExchanged); err != nil {
+	if err = s.sendEvent(ctx, tx, spi.IssuerOIDCInteractionAuthorizationCodeExchanged); err != nil {
 		return "", err
 	}
 

--- a/pkg/service/oidc4ci/oidc4ci_service_exchange_code_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_exchange_code_test.go
@@ -41,8 +41,8 @@ func TestExchangeCode(t *testing.T) {
 	opState := uuid.NewString()
 	authCode := uuid.NewString()
 
-	eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-		DoAndReturn(func(topic string, messages ...*spi.Event) error {
+	eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 			assert.Len(t, messages, 1)
 			assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionAuthorizationCodeExchanged)
 
@@ -128,8 +128,8 @@ func TestExchangeCodeProfileGetError(t *testing.T) {
 
 	profileService.EXPECT().GetProfile(gomock.Any()).Return(nil, errors.New("get profile error"))
 
-	eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-		DoAndReturn(func(topic string, messages ...*spi.Event) error {
+	eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 			assert.Len(t, messages, 1)
 			assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -164,8 +164,8 @@ func TestExchangeCodeIssuerError(t *testing.T) {
 		},
 	}, nil)
 
-	eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-		DoAndReturn(func(topic string, messages ...*spi.Event) error {
+	eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 			assert.Len(t, messages, 1)
 			assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -218,8 +218,8 @@ func TestExchangeCodeStoreUpdateErr(t *testing.T) {
 		},
 	}
 
-	eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-		DoAndReturn(func(topic string, messages ...*spi.Event) error {
+	eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 			assert.Len(t, messages, 1)
 			assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -267,8 +267,8 @@ func TestExchangeCodeInvalidState(t *testing.T) {
 		},
 	}, nil)
 
-	eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-		DoAndReturn(func(topic string, messages ...*spi.Event) error {
+	eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 			assert.Len(t, messages, 1)
 			assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -299,8 +299,8 @@ func TestExchangeCodePublishError(t *testing.T) {
 	opState := uuid.NewString()
 	authCode := uuid.NewString()
 
-	eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-		DoAndReturn(func(topic string, messages ...*spi.Event) error {
+	eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 			assert.Len(t, messages, 1)
 			assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionAuthorizationCodeExchanged)
 

--- a/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance.go
@@ -119,7 +119,7 @@ func (s *Service) InitiateIssuance( // nolint:funlen,gocyclo,gocognit
 		}
 	}
 
-	if errSendEvent := s.sendEvent(tx, spi.IssuerOIDCInteractionInitiated); errSendEvent != nil {
+	if errSendEvent := s.sendEvent(ctx, tx, spi.IssuerOIDCInteractionInitiated); errSendEvent != nil {
 		return nil, errSendEvent
 	}
 

--- a/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance_test.go
@@ -86,8 +86,8 @@ func TestService_InitiateIssuance(t *testing.T) {
 						InitiateIssuanceEndpoint: "https://wallet.example.com/initiate_issuance",
 					}, nil)
 
-				eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionInitiated)
 
@@ -147,8 +147,8 @@ func TestService_InitiateIssuance(t *testing.T) {
 
 				mockClaimDataStore.EXPECT().Create(gomock.Any(), gomock.Any()).Return("claimDataID", nil)
 
-				eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionInitiated)
 
@@ -221,8 +221,8 @@ func TestService_InitiateIssuance(t *testing.T) {
 
 				mockClaimDataStore.EXPECT().Create(gomock.Any(), gomock.Any()).Return("claimDataID", nil)
 
-				eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionInitiated)
 
@@ -283,8 +283,8 @@ func TestService_InitiateIssuance(t *testing.T) {
 
 				mockClaimDataStore.EXPECT().Create(gomock.Any(), gomock.Any()).Return("claimDataID", nil)
 
-				eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionInitiated)
 
@@ -436,8 +436,8 @@ func TestService_InitiateIssuance(t *testing.T) {
 
 				mockClaimDataStore.EXPECT().Create(gomock.Any(), gomock.Any()).Return("claimDataID", nil)
 
-				eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionInitiated)
 
@@ -603,8 +603,8 @@ func TestService_InitiateIssuance(t *testing.T) {
 					OpState:                   "eyJhbGciOiJSU0Et",
 				}
 
-				eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionInitiated)
 
@@ -630,8 +630,8 @@ func TestService_InitiateIssuance(t *testing.T) {
 				mockWellKnownService.EXPECT().GetOIDCConfiguration(gomock.Any(), walletWellKnownURL).Return(
 					nil, errors.New("invalid json"))
 
-				eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionInitiated)
 

--- a/pkg/service/oidc4ci/oidc4ci_service_store_auth_code.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_store_auth_code.go
@@ -27,12 +27,12 @@ func (s *Service) StoreAuthorizationCode(
 
 	tx.IssuerAuthCode = code
 	if err = s.store.Update(ctx, tx); err != nil {
-		s.sendFailedEvent(tx, err)
+		s.sendFailedEvent(ctx, tx, err)
 		return "", err
 	}
 
-	if err = s.sendEvent(tx, spi.IssuerOIDCInteractionAuthorizationCodeStored); err != nil {
-		s.sendFailedEvent(tx, err)
+	if err = s.sendEvent(ctx, tx, spi.IssuerOIDCInteractionAuthorizationCodeStored); err != nil {
+		s.sendFailedEvent(ctx, tx, err)
 		return "", err
 	}
 

--- a/pkg/service/oidc4ci/oidc4ci_service_store_auth_code_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_store_auth_code_test.go
@@ -58,8 +58,8 @@ func TestStoreAuthCode(t *testing.T) {
 				return errors.New("update error")
 			})
 
-		eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-			DoAndReturn(func(topic string, messages ...*spi.Event) error {
+		eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 				assert.Len(t, messages, 1)
 				assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -89,8 +89,8 @@ func TestStoreAuthCode(t *testing.T) {
 				return nil
 			})
 
-		eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-			DoAndReturn(func(topic string, messages ...*spi.Event) error {
+		eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 				assert.Len(t, messages, 1)
 				assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionAuthorizationCodeStored)
 
@@ -120,16 +120,16 @@ func TestStoreAuthCode(t *testing.T) {
 				return nil
 			})
 
-		eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-			DoAndReturn(func(topic string, messages ...*spi.Event) error {
+		eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 				assert.Len(t, messages, 1)
 				assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionAuthorizationCodeStored)
 
 				return errors.New("publish error")
 			})
 
-		eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-			DoAndReturn(func(topic string, messages ...*spi.Event) error {
+		eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 				assert.Len(t, messages, 1)
 				assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 

--- a/pkg/service/oidc4ci/oidc4ci_service_test.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_test.go
@@ -215,8 +215,8 @@ func TestService_PrepareClaimDataAuthorizationRequest(t *testing.T) {
 						return nil
 					}).Times(2)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionAuthorizationRequestPrepared)
 
@@ -260,16 +260,16 @@ func TestService_PrepareClaimDataAuthorizationRequest(t *testing.T) {
 						return nil
 					}).Times(2)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionAuthorizationRequestPrepared)
 
 						return errors.New("publish event")
 					})
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -372,8 +372,8 @@ func TestService_PrepareClaimDataAuthorizationRequest(t *testing.T) {
 					},
 				}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -413,8 +413,8 @@ func TestService_PrepareClaimDataAuthorizationRequest(t *testing.T) {
 					},
 				}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -452,8 +452,8 @@ func TestService_PrepareClaimDataAuthorizationRequest(t *testing.T) {
 					},
 				}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -525,8 +525,8 @@ func TestValidatePreAuthCode(t *testing.T) {
 			},
 		}, nil)
 
-		eventService.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-			DoAndReturn(func(topic string, messages ...*spi.Event) error {
+		eventService.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 				assert.Len(t, messages, 1)
 				assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionQRScanned)
 
@@ -550,8 +550,8 @@ func TestValidatePreAuthCode(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-			DoAndReturn(func(topic string, messages ...*spi.Event) error {
+		eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 				assert.Len(t, messages, 1)
 				assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionQRScanned)
 
@@ -583,8 +583,8 @@ func TestValidatePreAuthCode(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-			DoAndReturn(func(topic string, messages ...*spi.Event) error {
+		eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 				assert.Len(t, messages, 1)
 				assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionQRScanned)
 
@@ -732,8 +732,8 @@ func TestService_PrepareCredential(t *testing.T) {
 						return nil
 					})
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionSucceeded)
 
@@ -782,8 +782,8 @@ func TestService_PrepareCredential(t *testing.T) {
 						return nil
 					})
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionSucceeded)
 
@@ -818,8 +818,8 @@ func TestService_PrepareCredential(t *testing.T) {
 					},
 				}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionSucceeded)
 
@@ -859,7 +859,7 @@ func TestService_PrepareCredential(t *testing.T) {
 					},
 				}, nil)
 
-				eventMock.EXPECT().Publish(gomock.Any(), gomock.Any()).Times(0)
+				eventMock.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				mockTransactionStore.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
 
 				mockClaimDataStore.EXPECT().GetAndDelete(gomock.Any(), gomock.Any()).Return(nil, errors.New("get error"))
@@ -897,16 +897,16 @@ func TestService_PrepareCredential(t *testing.T) {
 
 				mockClaimDataStore.EXPECT().GetAndDelete(gomock.Any(), gomock.Any()).Return(&oidc4ci.ClaimData{}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionSucceeded)
 
 						return errors.New("publish error")
 					})
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -946,8 +946,8 @@ func TestService_PrepareCredential(t *testing.T) {
 
 				mockClaimDataStore.EXPECT().GetAndDelete(gomock.Any(), gomock.Any()).Return(&oidc4ci.ClaimData{}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -987,8 +987,8 @@ func TestService_PrepareCredential(t *testing.T) {
 					TransactionData: oidc4ci.TransactionData{},
 				}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 
@@ -1082,8 +1082,8 @@ func TestService_PrepareCredential(t *testing.T) {
 					},
 				}, nil)
 
-				eventMock.EXPECT().Publish(spi.IssuerEventTopic, gomock.Any()).
-					DoAndReturn(func(topic string, messages ...*spi.Event) error {
+				eventMock.EXPECT().Publish(gomock.Any(), spi.IssuerEventTopic, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, topic string, messages ...*spi.Event) error {
 						assert.Len(t, messages, 1)
 						assert.Equal(t, messages[0].Type, spi.IssuerOIDCInteractionFailed)
 

--- a/pkg/service/oidc4vp/oidc4vp_service_test.go
+++ b/pkg/service/oidc4vp/oidc4vp_service_test.go
@@ -517,7 +517,7 @@ type mockEvent struct {
 	err error
 }
 
-func (m *mockEvent) Publish(topic string, messages ...*spi.Event) error {
+func (m *mockEvent) Publish(ctx context2.Context, topic string, messages ...*spi.Event) error {
 	if m.err != nil {
 		return m.err
 	}


### PR DESCRIPTION
Added context.Context to Publish function signature in preparation for integration with OpenTelemetry.

Also removed options from event publisher/subscriber since they weren't being used.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>