### PR TITLE
chore: Add pre-auth code expiry

### DIFF
--- a/cmd/vc-rest/startcmd/start.go
+++ b/cmd/vc-rest/startcmd/start.go
@@ -324,6 +324,7 @@ func buildEchoHandler(conf *Configuration, cmd *cobra.Command) (*echo.Echo, erro
 		HTTPClient:                    httpClient,
 		EventService:                  eventSvc,
 		PinGenerator:                  otp.NewPinGenerator(),
+		PreAuthCodeTTL:                conf.StartupParameters.claimDataTTL,
 		EventTopic:                    conf.StartupParameters.issuerEventTopic,
 		CredentialOfferReferenceStore: credentialOfferStore,
 	})

--- a/pkg/service/oidc4ci/models.go
+++ b/pkg/service/oidc4ci/models.go
@@ -59,6 +59,7 @@ type TransactionData struct {
 	OpState                            string
 	IsPreAuthFlow                      bool
 	PreAuthCode                        string
+	PreAuthCodeExpiresAt               *time.Time
 	ClaimDataID                        string
 	State                              TransactionState
 	WebHookURL                         string

--- a/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance.go
+++ b/pkg/service/oidc4ci/oidc4ci_service_initiate_issuance.go
@@ -95,6 +95,7 @@ func (s *Service) InitiateIssuance( // nolint:funlen,gocyclo,gocognit
 
 		data.IsPreAuthFlow = true
 		data.PreAuthCode = generatePreAuthCode()
+		data.PreAuthCodeExpiresAt = lo.ToPtr(time.Now().UTC().Add(time.Duration(s.preAuthCodeTTL) * time.Second))
 		data.OpState = data.PreAuthCode // set opState as it will be empty for pre-auth
 	}
 

--- a/pkg/storage/mongodb/oidc4cistore/oidc4vc_store.go
+++ b/pkg/storage/mongodb/oidc4cistore/oidc4vc_store.go
@@ -56,6 +56,7 @@ type mongoDocument struct {
 	DID                                string
 	UserPin                            string
 	CredentialExpiresAt                *time.Time
+	PreAuthCodeExpiresAt               *time.Time
 }
 
 // Store stores oidc transactions in mongo.
@@ -218,6 +219,7 @@ func (s *Store) mapTransactionDataToMongoDocument(data *oidc4ci.TransactionData)
 		WebHookURL:                         data.WebHookURL,
 		DID:                                data.DID,
 		CredentialExpiresAt:                data.CredentialExpiresAt,
+		PreAuthCodeExpiresAt:               data.PreAuthCodeExpiresAt,
 	}
 }
 
@@ -250,6 +252,7 @@ func mapDocumentToTransaction(doc *mongoDocument) *oidc4ci.Transaction {
 			WebHookURL:                         doc.WebHookURL,
 			DID:                                doc.DID,
 			CredentialExpiresAt:                doc.CredentialExpiresAt,
+			PreAuthCodeExpiresAt:               doc.PreAuthCodeExpiresAt,
 		},
 	}
 }


### PR DESCRIPTION
Set pre-auth code expiry time when pre-auth code gets created (same as claim data expiry) 
Add check for pre-auth code expiry to ValidatePreAuthorizedCodeRequest function.

Message returned:
"url":"/issuer/interactions/validate-pre-authorized-code",
"httpStatus":400,
"additionalMessage":"map[code:oidc-tx-not-found incorrectValue: message:invalid pre-authorization code]"

"url":"/oidc/token",
"httpStatus":400,
"additionalMessage":"map[_raw:validate pre-authorized code request: status code 400, code: oidc-tx-not-found; message: invalid pre-authorization code error:invalid_grant]"



Closes #1127