### PR TITLE
feat: Added HTTP client metrics

### DIFF
--- a/component/credentialstatus/credentialstatus_service.go
+++ b/component/credentialstatus/credentialstatus_service.go
@@ -10,7 +10,6 @@ package credentialstatus
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +22,7 @@ import (
 	"github.com/piprate/json-gold/ld"
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/logutil-go/pkg/log"
+
 	"github.com/trustbloc/vcs/pkg/doc/vc"
 
 	"github.com/trustbloc/vcs/pkg/doc/vc/bitstring"
@@ -71,7 +71,7 @@ type kmsRegistry interface {
 }
 
 type Config struct {
-	TLSConfig      *tls.Config
+	HTTPClient     httpClient
 	RequestTokens  map[string]string
 	VDR            vdrapi.Registry
 	CSLStore       credentialstatus.CSLStore
@@ -101,7 +101,7 @@ type Service struct {
 // New returns new Credential Status service.
 func New(config *Config) (*Service, error) {
 	return &Service{
-		httpClient:     &http.Client{Transport: &http.Transport{TLSClientConfig: config.TLSConfig}},
+		httpClient:     config.HTTPClient,
 		requestTokens:  config.RequestTokens,
 		vdr:            config.VDR,
 		cslStore:       config.CSLStore,

--- a/component/profile/reader/file/reader.go
+++ b/component/profile/reader/file/reader.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -39,11 +40,16 @@ const (
 
 var logger = log.New("vc-rest")
 
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Config contain config.
 type Config struct {
 	KMSRegistry *vcskms.Registry
 	TLSConfig   *tls.Config
 	CMD         *cobra.Command
+	HTTPClient  httpClient
 }
 
 // IssuerReader read issuer profiles.

--- a/pkg/observability/metrics/noop/provider.go
+++ b/pkg/observability/metrics/noop/provider.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package noop
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/trustbloc/vcs/pkg/observability/metrics"
@@ -23,3 +24,8 @@ func GetMetrics() metrics.Metrics {
 func (n *NoMetrics) SignTime(_ time.Duration)                             {}
 func (n *NoMetrics) CheckAuthorizationResponseTime(_ time.Duration)       {}
 func (n *NoMetrics) VerifyOIDCVerifiablePresentationTime(_ time.Duration) {}
+
+// InstrumentHTTPTransport simply returns the provided transport.
+func (n *NoMetrics) InstrumentHTTPTransport(_ metrics.ClientID, transport http.RoundTripper) http.RoundTripper {
+	return transport
+}

--- a/pkg/observability/metrics/noop/provider_test.go
+++ b/pkg/observability/metrics/noop/provider_test.go
@@ -7,10 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package noop
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/vcs/pkg/observability/metrics"
 )
 
 func TestMetrics(t *testing.T) {
@@ -22,4 +25,15 @@ func TestMetrics(t *testing.T) {
 		require.NotPanics(t, func() { m.CheckAuthorizationResponseTime(time.Second) })
 		require.NotPanics(t, func() { m.VerifyOIDCVerifiablePresentationTime(time.Second) })
 	})
+}
+
+func TestMetrics_InstrumentHTTPTransport(t *testing.T) {
+	m := GetMetrics()
+	require.NotNil(t, m)
+
+	t1 := http.DefaultTransport
+
+	t2 := m.InstrumentHTTPTransport(metrics.ClientVerifierProfile, t1)
+	require.NotNil(t, t2)
+	require.True(t, t1 == t2)
 }

--- a/pkg/observability/metrics/prometheus/provider.go
+++ b/pkg/observability/metrics/prometheus/provider.go
@@ -9,6 +9,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -21,6 +22,12 @@ import (
 )
 
 var logger = metrics.Logger
+
+const (
+	clientIDLabel = "clientID"
+	codeLabel     = "code"
+	methodLabel   = "method"
+)
 
 var (
 	createOnce sync.Once       //nolint:gochecknoglobals
@@ -80,6 +87,10 @@ func GetMetrics() metrics.Metrics {
 
 // PromMetrics manages the metrics for VCS.
 type PromMetrics struct {
+	httpInFlight        map[metrics.ClientID]prometheus.Gauge
+	httpTotalRequests   map[metrics.ClientID]*prometheus.CounterVec
+	httpRequestDuration map[metrics.ClientID]prometheus.ObserverVec
+
 	signTime          prometheus.Histogram
 	checkAuthRespTime prometheus.Histogram
 	verifyOIDCVPTime  prometheus.Histogram
@@ -87,13 +98,25 @@ type PromMetrics struct {
 
 // NewMetrics creates instance of prometheus metrics.
 func NewMetrics() metrics.Metrics {
+	httpClients := []metrics.ClientID{
+		metrics.ClientPreAuth, metrics.ClientCredentialStatus,
+		metrics.ClientIssuerProfile, metrics.ClientVerifierProfile,
+		metrics.ClientIssuerInteraction, metrics.ClientOIDC4PV1,
+		metrics.ClientOIDC4CI, metrics.ClientOIDC4CIV1,
+		metrics.ClientWellKnown,
+	}
+
 	pm := &PromMetrics{
+		httpInFlight:        newHTTPClientInFlightRequests(httpClients),
+		httpTotalRequests:   newHTTPClientTotalRequests(httpClients),
+		httpRequestDuration: newHTTPClientRequestTime(httpClients),
+
 		signTime:          newSignTime(),
 		checkAuthRespTime: newCheckAuthRespTime(),
 		verifyOIDCVPTime:  newVerifyOIDCVPTime(),
 	}
 
-	registerMetrics(pm)
+	pm.register()
 
 	return pm
 }
@@ -118,10 +141,40 @@ func (pm *PromMetrics) VerifyOIDCVerifiablePresentationTime(value time.Duration)
 	logger.Debug("VerifyOIDCVerifiablePresentation service call time", log.WithDuration(value))
 }
 
-func registerMetrics(pm *PromMetrics) {
+// InstrumentHTTPTransport instruments the given HTTP transport with metrics such as
+// request duration, number of in-flight requests, etc.
+func (pm *PromMetrics) InstrumentHTTPTransport(id metrics.ClientID, transport http.RoundTripper) http.RoundTripper {
+	inFlight := pm.httpInFlight[id]
+	totalRequests := pm.httpTotalRequests[id]
+	requestDuration := pm.httpRequestDuration[id]
+
+	if inFlight == nil || totalRequests == nil || requestDuration == nil {
+		panic(fmt.Sprintf("client not found for HTTP client metric [%s]", id))
+	}
+
+	return promhttp.InstrumentRoundTripperInFlight(inFlight,
+		promhttp.InstrumentRoundTripperCounter(totalRequests,
+			promhttp.InstrumentRoundTripperDuration(requestDuration, transport),
+		),
+	)
+}
+
+func (pm *PromMetrics) register() {
 	prometheus.MustRegister(
 		pm.signTime, pm.checkAuthRespTime, pm.verifyOIDCVPTime,
 	)
+
+	for _, m := range pm.httpInFlight {
+		prometheus.MustRegister(m)
+	}
+
+	for _, m := range pm.httpTotalRequests {
+		prometheus.MustRegister(m)
+	}
+
+	for _, m := range pm.httpRequestDuration {
+		prometheus.MustRegister(m)
+	}
 }
 
 func newCounter(subsystem, name, help string, labels prometheus.Labels) prometheus.Counter {
@@ -132,6 +185,16 @@ func newCounter(subsystem, name, help string, labels prometheus.Labels) promethe
 		Help:        help,
 		ConstLabels: labels,
 	})
+}
+
+func newCounterVec(subsystem, name, help string, labels prometheus.Labels, varLabels ...string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   metrics.Namespace,
+		Subsystem:   subsystem,
+		Name:        name,
+		Help:        help,
+		ConstLabels: labels,
+	}, varLabels)
 }
 
 func newGauge(subsystem, name, help string, labels prometheus.Labels) prometheus.Gauge {
@@ -152,6 +215,17 @@ func newHistogram(subsystem, name, help string, labels prometheus.Labels) promet
 		Help:        help,
 		ConstLabels: labels,
 	})
+}
+
+func newHistogramVec(subsystem, name, help string, labels prometheus.Labels,
+	varLabels ...string) prometheus.ObserverVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:   metrics.Namespace,
+		Subsystem:   subsystem,
+		Name:        name,
+		Help:        help,
+		ConstLabels: labels,
+	}, varLabels)
 }
 
 func newSignTime() prometheus.Histogram {
@@ -176,4 +250,41 @@ func newVerifyOIDCVPTime() prometheus.Histogram {
 		"The time (in seconds) it takes to execute VerifyOIDCVerifiablePresentation service call.",
 		nil,
 	)
+}
+
+func newHTTPClientInFlightRequests(clients []metrics.ClientID) map[metrics.ClientID]prometheus.Gauge {
+	m := make(map[metrics.ClientID]prometheus.Gauge)
+
+	for _, id := range clients {
+		m[id] = newGauge(metrics.HTTPClient, metrics.HTTPClientInFlightRequests,
+			"The number of in-flight requests for the HTTP client.",
+			prometheus.Labels{clientIDLabel: string(id)})
+	}
+
+	return m
+}
+
+func newHTTPClientTotalRequests(clients []metrics.ClientID) map[metrics.ClientID]*prometheus.CounterVec {
+	m := make(map[metrics.ClientID]*prometheus.CounterVec)
+
+	for _, id := range clients {
+		m[id] = newCounterVec(metrics.HTTPClient, metrics.HTTPClientTotalRequests,
+			"The total number of requests for the HTTP client.",
+			prometheus.Labels{clientIDLabel: string(id)}, codeLabel, methodLabel)
+	}
+
+	return m
+}
+
+func newHTTPClientRequestTime(clients []metrics.ClientID) map[metrics.ClientID]prometheus.ObserverVec {
+	m := make(map[metrics.ClientID]prometheus.ObserverVec)
+
+	for _, id := range clients {
+		m[id] = newHistogramVec(metrics.HTTPClient, metrics.HTTPClientRequestDuration,
+			"The duration (in seconds) of an HTTP request.",
+			prometheus.Labels{clientIDLabel: string(id)}, methodLabel,
+		)
+	}
+
+	return m
 }

--- a/pkg/observability/metrics/prometheus/provider_test.go
+++ b/pkg/observability/metrics/prometheus/provider_test.go
@@ -7,12 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package prometheus
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/vcs/pkg/observability/metrics"
 )
 
 func TestPromProvider(t *testing.T) {
@@ -55,4 +58,19 @@ func TestNewHistogram(t *testing.T) {
 	labels := prometheus.Labels{"type": "create"}
 
 	require.NotNil(t, newHistogram("activityPub", "metric_name", "Some help", labels))
+}
+
+func TestMetrics_InstrumentHTTPTransport(t *testing.T) {
+	m := GetMetrics()
+	require.NotNil(t, m)
+
+	t1 := http.DefaultTransport
+
+	t2 := m.InstrumentHTTPTransport(metrics.ClientVerifierProfile, t1)
+	require.NotNil(t, t2)
+	require.False(t, t1 == t2)
+
+	require.Panics(t, func() {
+		m.InstrumentHTTPTransport("unknown", t1)
+	})
 }

--- a/pkg/observability/metrics/provider.go
+++ b/pkg/observability/metrics/provider.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package metrics
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/trustbloc/logutil-go/pkg/log"
@@ -31,6 +32,30 @@ const (
 	// Service operations.
 	Service      = "service"
 	VerifyOIDCVP = "service_verifyOIDCVerifiablePresentation_seconds"
+
+	// HTTPServer HTTP server subsystem.
+	HTTPServer = "httpserver"
+
+	// HTTPClient HTTP client subsystem.
+	HTTPClient                 = "httpclient"
+	HTTPClientInFlightRequests = "in_flight_requests"
+	HTTPClientTotalRequests    = "requests_total"
+	HTTPClientRequestDuration  = "request_duration_seconds"
+)
+
+// ClientID defines the ID of the client.
+type ClientID string
+
+const (
+	ClientPreAuth           ClientID = "preauthorize"
+	ClientIssuerProfile     ClientID = "issuer-profile"
+	ClientVerifierProfile   ClientID = "verifier-profile"
+	ClientCredentialStatus  ClientID = "credential-status" //nolint:gosec
+	ClientOIDC4CI           ClientID = "oidc4ci"
+	ClientOIDC4CIV1         ClientID = "oidc4civ1"
+	ClientOIDC4PV1          ClientID = "oidc4pv1"
+	ClientWellKnown         ClientID = "wellknown"
+	ClientIssuerInteraction ClientID = "issuer-interaction"
 )
 
 // Provider is an interface for metrics provider.
@@ -50,4 +75,6 @@ type Metrics interface {
 	SignTime(value time.Duration)
 	CheckAuthorizationResponseTime(value time.Duration)
 	VerifyOIDCVerifiablePresentationTime(value time.Duration)
+
+	InstrumentHTTPTransport(ClientID, http.RoundTripper) http.RoundTripper
 }


### PR DESCRIPTION
Added (Prometheus) HTTP client metrics. Also changed the namespace/subsystem of the HTTP server metrics to vcs/httpserver to differentiate between metrics of other microservices and also to differentiate between client and server metrics in the vcs microservice.