### PR TITLE
chore: cleanup obsolete openapi spec 2.0 and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ The VCS uses golang packages from [Hyperledger Aries Framework Go]([aries-framew
 To build from source see [here](docs/build.md).
 
 ## Documentation
-- [VC Services](docs/vcs/README.md)
-- [OpenAPI Spec](docs/vc-rest/openapi_spec.md)
-- [OpenAPI Demo](docs/vc-rest/openapi_demo.md)
+- [OpenAPI Spec](https://trustbloc.github.io/vcs/)
 
 ## Contributing
 Thank you for your interest in contributing. Please see our [community contribution guidelines](https://github.com/trustbloc/community/blob/main/CONTRIBUTING.md) for more information.

--- a/cmd/vc-rest/main.go
+++ b/cmd/vc-rest/main.go
@@ -4,21 +4,6 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package vc-rest VC Issuer, Verifier and Holder REST API.
-//
-// Terms Of Service:
-//
-//	Schemes: http, https
-//	Version: 0.1.0
-//	License: SPDX-License-Identifier: Apache-2.0
-//
-//	Consumes:
-//	- application/json
-//
-//	Produces:
-//	- application/json
-//
-// swagger:meta
 package main
 
 import (

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -178,19 +178,6 @@ services:
     networks:
       - bdd_net
 
-  vc-openapi.trustbloc.local:
-    container_name: vc-openapi.trustbloc.local
-    image: swaggerapi/swagger-ui
-    environment:
-      - SWAGGER_JSON=/spec/openAPI.yml
-      - BASE_URL=/openapi
-    ports:
-      - "8089:8080"
-    volumes:
-      - ./spec:/spec
-    networks:
-      - bdd_net
-
   api-gateway.trustbloc.local:
     container_name: api-gateway.trustbloc.local
     image: devopsfaith/krakend:${KRAKEND_IMAGE_TAG}


### PR DESCRIPTION
Note: project has been switched to oapi-codegen for generating Go boilerplate code based on OpenAPI 3.0 API definitions (docs/v1/openapi.yaml)

Signed-off-by: Andrii Holovko <andriy.holovko@gmail.com>