### PR TITLE
fix: oidc credential format and other minor issues

### DIFF
--- a/component/oidc/fositemongo/access_token.go
+++ b/component/oidc/fositemongo/access_token.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/access_token_test.go
+++ b/component/oidc/fositemongo/access_token_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -36,7 +42,7 @@ func TestAccessTokenFlow(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	testCases := []struct {

--- a/component/oidc/fositemongo/assertions.go
+++ b/component/oidc/fositemongo/assertions.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/assertions_test.go
+++ b/component/oidc/fositemongo/assertions_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/auth_code.go
+++ b/component/oidc/fositemongo/auth_code.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/auth_code_test.go
+++ b/component/oidc/fositemongo/auth_code_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -20,7 +26,7 @@ func TestAuthCode(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	testCases := []struct {

--- a/component/oidc/fositemongo/client.go
+++ b/component/oidc/fositemongo/client.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/client_test.go
+++ b/component/oidc/fositemongo/client_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -18,7 +24,7 @@ func TestClientAsserting(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)
@@ -60,7 +66,7 @@ func TestClientAssertingWithExpiration(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.jti, func(t *testing.T) {
-			client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+			client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 			assert.NoError(t, mongoErr)
 
 			s, err := NewStore(context.Background(), client)

--- a/component/oidc/fositemongo/common_test.go
+++ b/component/oidc/fositemongo/common_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -20,7 +26,7 @@ func TestCreateSessionWithoutClient(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)
@@ -51,7 +57,7 @@ func TestCreateSessionWithAccessRequest(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)
@@ -84,7 +90,7 @@ func TestCreateSessionWithoutMongoErr(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)
@@ -105,7 +111,7 @@ func TestCreateExpiredSession(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	dbClient := &Client{

--- a/component/oidc/fositemongo/fosite_mongo.go
+++ b/component/oidc/fositemongo/fosite_mongo.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/fosite_mongo_test.go
+++ b/component/oidc/fositemongo/fosite_mongo_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -17,7 +23,7 @@ func TestFailMigration(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	ctx, cancel := context.WithCancel(context.TODO())

--- a/component/oidc/fositemongo/go.mod
+++ b/component/oidc/fositemongo/go.mod
@@ -1,3 +1,4 @@
+// Copyright Avast Software. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/component/oidc/fositemongo/par.go
+++ b/component/oidc/fositemongo/par.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/par_test.go
+++ b/component/oidc/fositemongo/par_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -19,7 +25,7 @@ func TestPar(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	testCases := []struct {
@@ -89,7 +95,7 @@ func TestRequestInvalidSession(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)
@@ -107,7 +113,7 @@ func TestRequestInvalidParSessionWithoutClient(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)

--- a/component/oidc/fositemongo/pkce.go
+++ b/component/oidc/fositemongo/pkce.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/pkce_test.go
+++ b/component/oidc/fositemongo/pkce_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -20,7 +26,7 @@ func TestPKCE(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	testCases := []struct {

--- a/component/oidc/fositemongo/refresh_token.go
+++ b/component/oidc/fositemongo/refresh_token.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/refresh_token_test.go
+++ b/component/oidc/fositemongo/refresh_token_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -20,7 +26,7 @@ func TestRefreshTokenFlow(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	type deleteType int
@@ -115,7 +121,7 @@ func TestFailGracePeriod(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)

--- a/component/oidc/fositemongo/store.go
+++ b/component/oidc/fositemongo/store.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/store_test.go
+++ b/component/oidc/fositemongo/store_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (
@@ -18,7 +24,7 @@ func TestStoreFail(t *testing.T) {
 		assert.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
 	}()
 
-	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", time.Second*10)
+	client, mongoErr := mongodb.New(mongoDBConnString, "testdb", mongodb.WithTimeout(time.Second*10))
 	assert.NoError(t, mongoErr)
 
 	s, err := NewStore(context.Background(), client)

--- a/component/oidc/fositemongo/types.go
+++ b/component/oidc/fositemongo/types.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/component/oidc/fositemongo/types_test.go
+++ b/component/oidc/fositemongo/types_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package fositemongo
 
 import (

--- a/pkg/service/oidc4ci/api.go
+++ b/pkg/service/oidc4ci/api.go
@@ -70,7 +70,6 @@ type TransactionData struct {
 	CredentialExpiresAt                *time.Time
 	CredentialName                     string
 	CredentialDescription              string
-	OidcFormat                         vcsverifiable.OIDCFormat
 }
 
 // AuthorizationDetails are the VC-related details for VC issuance.

--- a/pkg/storage/mongodb/oidc4cistore/oidc4vc_store.go
+++ b/pkg/storage/mongodb/oidc4cistore/oidc4vc_store.go
@@ -36,7 +36,7 @@ type mongoDocument struct {
 	OrgID                              string
 	CredentialTemplate                 *profileapi.CredentialTemplate
 	CredentialFormat                   vcsverifiable.Format
-	OidcFormat                         vcsverifiable.OIDCFormat
+	OIDCCredentialFormat               vcsverifiable.OIDCFormat
 	ClaimEndpoint                      string
 	GrantType                          string
 	ResponseType                       string
@@ -202,6 +202,7 @@ func (s *Store) mapTransactionDataToMongoDocument(data *oidc4ci.TransactionData)
 		OrgID:                              data.OrgID,
 		CredentialTemplate:                 data.CredentialTemplate,
 		CredentialFormat:                   data.CredentialFormat,
+		OIDCCredentialFormat:               data.OIDCCredentialFormat,
 		ClaimEndpoint:                      data.ClaimEndpoint,
 		GrantType:                          data.GrantType,
 		ResponseType:                       data.ResponseType,
@@ -225,7 +226,6 @@ func (s *Store) mapTransactionDataToMongoDocument(data *oidc4ci.TransactionData)
 		PreAuthCodeExpiresAt:               data.PreAuthCodeExpiresAt,
 		CredentialDescription:              data.CredentialDescription,
 		CredentialName:                     data.CredentialName,
-		OidcFormat:                         data.OidcFormat,
 	}
 }
 
@@ -237,6 +237,7 @@ func mapDocumentToTransaction(doc *mongoDocument) *oidc4ci.Transaction {
 			OrgID:                              doc.OrgID,
 			CredentialTemplate:                 doc.CredentialTemplate,
 			CredentialFormat:                   doc.CredentialFormat,
+			OIDCCredentialFormat:               doc.OIDCCredentialFormat,
 			AuthorizationEndpoint:              doc.AuthorizationEndpoint,
 			PushedAuthorizationRequestEndpoint: doc.PushedAuthorizationRequestEndpoint,
 			TokenEndpoint:                      doc.TokenEndpoint,
@@ -261,7 +262,6 @@ func mapDocumentToTransaction(doc *mongoDocument) *oidc4ci.Transaction {
 			PreAuthCodeExpiresAt:               doc.PreAuthCodeExpiresAt,
 			CredentialDescription:              doc.CredentialDescription,
 			CredentialName:                     doc.CredentialName,
-			OidcFormat:                         doc.OidcFormat,
 		},
 	}
 }

--- a/pkg/storage/mongodb/oidc4cistore/oidc4vc_store_test.go
+++ b/pkg/storage/mongodb/oidc4cistore/oidc4vc_store_test.go
@@ -95,6 +95,7 @@ func TestStore(t *testing.T) {
 			},
 			ProfileID:                          "profileID",
 			CredentialFormat:                   vcsverifiable.Ldp,
+			OIDCCredentialFormat:               vcsverifiable.JwtVCJsonLD,
 			AuthorizationEndpoint:              "authEndpoint",
 			PushedAuthorizationRequestEndpoint: "pushedAuth",
 			TokenEndpoint:                      "tokenEndpoint",

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -66,4 +66,24 @@ go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeou
 amend_coverage_file
 cd "$pwd"
 
+# Running oidc fositemongo unit tests
+echo "... done"
+echo "oidc fositemongo unit tests..."
+cd component/oidc/fositemongo
+PKGS=`go list github.com/trustbloc/vcs/component/oidc/fositemongo... 2> /dev/null | \
+                                                 grep -v /mocks`
+go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
+amend_coverage_file
+cd "$pwd"
+
+# Running oidc vp unit tests
+echo "... done"
+echo "oidc vp unit tests..."
+cd component/oidc/vp
+PKGS=`go list github.com/trustbloc/vcs/component/oidc/vp... 2> /dev/null | \
+                                                 grep -v /mocks`
+go test $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
+amend_coverage_file
+cd "$pwd"
+
 echo "... done all unit-tests"

--- a/test/bdd/pkg/v1/oidc4ci/oidc4vc_pre_authorize_steps.go
+++ b/test/bdd/pkg/v1/oidc4ci/oidc4vc_pre_authorize_steps.go
@@ -171,7 +171,7 @@ func (s *PreAuthorizeStep) initiateIssuance(requirePin string) error {
 			"degreeSchool": "MIT school",
 		}),
 		CredentialTemplateId: "templateID",
-		GrantType:            "authorization_code",
+		GrantType:            "urn:ietf:params:oauth:grant-type:pre-authorized_code",
 		Scope:                []string{"openid", "profile"},
 	}
 	if strings.EqualFold(requirePin, "true") {


### PR DESCRIPTION
Fixed:
* empty value for oidc credential format in response from `/oidc/credential`
* missing license headers for fositemongo package
* not running unit-tests for oidc fosite and vp packages