### PR TITLE
fix: "iat" claim check

### DIFF
--- a/pkg/restapi/v1/oidc4ci/controller_e2e_flows_test.go
+++ b/pkg/restapi/v1/oidc4ci/controller_e2e_flows_test.go
@@ -163,9 +163,11 @@ func TestAuthorizeCodeGrantFlow(t *testing.T) {
 
 	httpClient := oauthClient.Client(context.Background(), token)
 
+	currentTime := time.Now().Unix()
+
 	claims := &oidc4ci.JWTProofClaims{
 		Issuer:   clientID,
-		IssuedAt: time.Now().Unix(),
+		IssuedAt: &currentTime,
 		Audience: srv.URL,
 		Nonce:    token.Extra("c_nonce").(string),
 	}

--- a/pkg/restapi/v1/oidc4ci/models.go
+++ b/pkg/restapi/v1/oidc4ci/models.go
@@ -29,6 +29,6 @@ type AuthorizationDetails struct {
 type JWTProofClaims struct {
 	Issuer   string `json:"iss,omitempty"`
 	Audience string `json:"aud,omitempty"`
-	IssuedAt int64  `json:"iat,omitempty"`
+	IssuedAt *int64 `json:"iat,omitempty"`
 	Nonce    string `json:"nonce,omitempty"`
 }


### PR DESCRIPTION
The "iat" claim check on the /credential endpoint now simply ensures that a value is set instead of requiring it to be within a specific range (which can cause issues depending on a client's clock setting).