### PR TITLE
feat: Validate issuer claims against JSON schema

### DIFF
--- a/pkg/profile/api.go
+++ b/pkg/profile/api.go
@@ -62,6 +62,7 @@ type CredentialTemplate struct {
 	CredentialDefaultExpirationDuration *time.Duration               `json:"credentialDefaultExpirationDuration"`
 	Checks                              CredentialTemplateChecks     `json:"checks"`
 	SdJWT                               *SelectiveDisclosureTemplate `json:"sdJWT"`
+	JSONSchema                          string                       `json:"jsonSchema,omitempty"`
 }
 
 type SelectiveDisclosureTemplate struct {

--- a/pkg/restapi/v1/issuer/testdata/sample_vc_invalid_university_degree.jsonld
+++ b/pkg/restapi/v1/issuer/testdata/sample_vc_invalid_university_degree.jsonld
@@ -7,17 +7,7 @@
   "credentialSchema": [],
   "credentialSubject": {
       "alumniOf": {
-        "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
-        "name": [
-            {
-              "value": "Example University",
-              "lang": "en"
-            },
-            {
-              "value": "Exemple d'Université",
-              "lang": "fr"
-            }
-        ]
+        "id": "did:example:c276e12ec21ebfeb1f712ebc6f1"
       },
       "degree": {
         "type": "BachelorDegree",

--- a/pkg/restapi/v1/issuer/testdata/universitydegree.schema.json
+++ b/pkg/restapi/v1/issuer/testdata/universitydegree.schema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "https://trustbloc.com/universitydegree.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "UniversityDegreeCredential",
+  "type": "object",
+  "properties": {
+    "alumniOf": {
+      "type": "object",
+      "description": "Describes the university.",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "array",
+          "description": "A list of language-specific names.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "lang": {
+                "type": "string"
+              }
+            },
+            "required": ["value", "lang"]
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["id", "name"]
+    },
+    "degree": {
+      "type": "object",
+      "description": "Describes the degree.",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["type","name"]
+    }
+  },
+  "required": ["alumniOf","degree"]
+}

--- a/test/bdd/features/oidc4vc_api.feature
+++ b/test/bdd/features/oidc4vc_api.feature
@@ -61,6 +61,11 @@ Feature: OIDC4VC REST API
     And   Issuer with id "bank_issuer/v1.0" is authorized as a Profile user
     Then User interacts with Wallet to initiate credential issuance using pre authorization code flow with invalid claims
 
+  Scenario: OIDC credential issuance and verification Pre Auth flow (Claims JSON schema validation error)
+    Given Organization "test_org" has been authorized with client id "f13d1va9lp403pb9lyj89vk55" and secret "ejqxi9jb1vew2jbdnogpjcgrz"
+    And   Issuer with id "bank_issuer/v1.0" is authorized as a Profile user
+    Then User interacts with Wallet to initiate credential issuance using pre authorization code flow with invalid claims schema
+
   Scenario: OIDC credential issuance and verification Pre Auth flow (Invalid Field in Presentation Definition)
     Given Organization "test_org" has been authorized with client id "f13d1va9lp403pb9lyj89vk55" and secret "ejqxi9jb1vew2jbdnogpjcgrz"
     And   Issuer with id "i_myprofile_ud_es256k_jwt/v1.0" is authorized as a Profile user

--- a/test/bdd/fixtures/profile/profiles.json
+++ b/test/bdd/fixtures/profile/profiles.json
@@ -704,6 +704,7 @@
               "https://www.w3.org/2018/credentials/v1",
               "https://www.w3.org/2018/credentials/examples/v1"
             ],
+            "jsonSchema": "{\"$id\":\"https://trustbloc.com/universitydegree.schema.json\",\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"UniversityDegreeCredential\",\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"spouse\":{\"type\":\"string\"},\"degree\":{\"type\":\"object\",\"description\":\"Describes the degree.\",\"properties\":{\"type\":{\"type\":\"string\"},\"degree\":{\"type\":\"string\"}},\"required\":[\"type\",\"degree\"]}},\"required\":[\"name\",\"spouse\",\"degree\"]}",
             "type": "UniversityDegreeCredential",
             "id": "universityDegreeTemplateID",
             "issuer": "did:orb:bank_issuer",

--- a/test/bdd/pkg/v1/oidc4vc/oidc4ci.go
+++ b/test/bdd/pkg/v1/oidc4vc/oidc4ci.go
@@ -163,6 +163,31 @@ func (s *Steps) runOIDC4CIPreAuthWithInvalidClaims() error {
 	return nil
 }
 
+func (s *Steps) runOIDC4CIPreAuthWithInvalidClaimsSchema() error {
+	initiateIssuanceRequest := initiateOIDC4CIRequest{
+		CredentialTemplateId: "universityDegreeTemplateID",
+		ClaimData: &map[string]interface{}{
+			"degree": map[string]string{
+				"degree": "MIT",
+			},
+			// "name":   "Jayden Doe",
+			"spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1",
+		},
+		UserPinRequired: true,
+	}
+
+	err := s.runOIDC4CIPreAuth(initiateIssuanceRequest)
+	if err == nil {
+		return errors.New("error expected")
+	}
+
+	if !strings.Contains(err.Error(), "validate claims: validation error: [(root): name is required; degree: type is required]") {
+		return fmt.Errorf("unexpected error: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Steps) fetchClaimData(issuedCredentialType string) (map[string]interface{}, error) {
 	resp, err := bddutil.HTTPSDo(
 		http.MethodPost,

--- a/test/bdd/pkg/v1/oidc4vc/steps.go
+++ b/test/bdd/pkg/v1/oidc4vc/steps.go
@@ -130,6 +130,7 @@ func (s *Steps) RegisterSteps(sc *godog.ScenarioContext) {
 
 	// Errors.
 	sc.Step(`^User interacts with Wallet to initiate credential issuance using pre authorization code flow with invalid claims$`, s.runOIDC4CIPreAuthWithInvalidClaims)
+	sc.Step(`^User interacts with Wallet to initiate credential issuance using pre authorization code flow with invalid claims schema$`, s.runOIDC4CIPreAuthWithInvalidClaimsSchema)
 	sc.Step(`^User interacts with Wallet to initiate credential issuance using pre authorization code flow and receives "([^"]*)" error$`, s.runOIDC4CIPreAuthWithError)
 	sc.Step(`^Verifier form organization "([^"]*)" requests deleted interactions claims$`, s.retrieveExpiredOrDeletedInteractionsClaim)
 	sc.Step(`^Verifier form organization "([^"]*)" requests expired interactions claims$`, s.retrieveExpiredOrDeletedInteractionsClaim)


### PR DESCRIPTION
Added a JSON schema field to the credentialTemplate profile element. If the "jsonSchema" field is not empty then the issuer claims are validated against the schema.