### PR TITLE
fix: params for oauth client manager

### DIFF
--- a/pkg/oauth2client/api.go
+++ b/pkg/oauth2client/api.go
@@ -16,8 +16,14 @@ import (
 var _ fosite.Client = (*Client)(nil)
 
 const (
-	defaultGrantType    = "authorization_code"
-	defaultResponseType = "code"
+	GrantTypeAuthorizationCode = "authorization_code"
+	GrantTypePreAuthorizedCode = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+
+	ResponseTypeCode = "code"
+
+	TokenEndpointAuthMethodNone              = "none"
+	TokenEndpointAuthMethodClientSecretBasic = "client_secret_basic"
+	TokenEndpointAuthMethodClientSecretPost  = "client_secret_post"
 )
 
 // Client represents an OAuth2 client.
@@ -26,7 +32,7 @@ type Client struct {
 	Name                    string              `json:"client_name"`
 	URI                     string              `json:"client_uri"`
 	Secret                  []byte              `json:"client_secret,omitempty"`
-	SecretExpiresAt         time.Time           `json:"client_secret_expires_at,omitempty"`
+	SecretExpiresAt         int64               `json:"client_secret_expires_at,omitempty"`
 	RotatedSecrets          [][]byte            `json:"rotated_secrets,omitempty"`
 	RedirectURIs            []string            `json:"redirect_uris"`
 	GrantTypes              []string            `json:"grant_types"`
@@ -63,7 +69,7 @@ func (c *Client) GetRedirectURIs() []string {
 // GetGrantTypes returns the client grant types.
 func (c *Client) GetGrantTypes() fosite.Arguments {
 	if len(c.GrantTypes) == 0 {
-		return fosite.Arguments{defaultGrantType}
+		return fosite.Arguments{GrantTypeAuthorizationCode}
 	}
 
 	return c.GrantTypes
@@ -72,7 +78,7 @@ func (c *Client) GetGrantTypes() fosite.Arguments {
 // GetResponseTypes returns the client response types.
 func (c *Client) GetResponseTypes() fosite.Arguments {
 	if len(c.ResponseTypes) == 0 {
-		return fosite.Arguments{defaultResponseType}
+		return fosite.Arguments{ResponseTypeCode}
 	}
 
 	return c.ResponseTypes
@@ -91,4 +97,28 @@ func (c *Client) IsPublic() bool {
 // GetAudience returns the client audience.
 func (c *Client) GetAudience() fosite.Arguments {
 	return c.Audience
+}
+
+// GrantTypesSupported returns grant types supported by the VCS OIDC provider.
+func GrantTypesSupported() []string {
+	return []string{
+		GrantTypeAuthorizationCode,
+		GrantTypePreAuthorizedCode,
+	}
+}
+
+// ResponseTypesSupported returns response types supported by the VCS OIDC provider.
+func ResponseTypesSupported() []string {
+	return []string{
+		ResponseTypeCode,
+	}
+}
+
+// TokenEndpointAuthMethodsSupported returns client authentication methods supported by the VCS token endpoint.
+func TokenEndpointAuthMethodsSupported() []string {
+	return []string{
+		TokenEndpointAuthMethodNone,
+		TokenEndpointAuthMethodClientSecretBasic,
+		TokenEndpointAuthMethodClientSecretPost,
+	}
 }

--- a/pkg/profile/api.go
+++ b/pkg/profile/api.go
@@ -96,20 +96,19 @@ type CredentialMetaData struct {
 
 // OIDCConfig represents issuer's OIDC configuration.
 type OIDCConfig struct {
-	IssuerWellKnownURL                         string        `json:"issuer_well_known"`
-	ClientID                                   string        `json:"client_id"`
-	ClientSecretHandle                         string        `json:"client_secret_handle"`
-	ScopesSupported                            []string      `json:"scopes_supported"`
-	GrantTypesSupported                        []string      `json:"grant_types_supported"`
-	ResponseTypesSupported                     []string      `json:"response_types_supported"`
-	TokenEndpointAuthMethodsSupported          []string      `json:"token_endpoint_auth_methods_supported"`
-	EnableDynamicClientRegistration            bool          `json:"enable_dynamic_client_registration"`
-	EnableDiscoverableClientIDScheme           bool          `json:"enable_discoverable_client_id_scheme"`
-	InitialAccessTokenLifespan                 time.Duration `json:"initial_access_token_lifespan"`
-	PreAuthorizedGrantAnonymousAccessSupported bool          `json:"pre-authorized_grant_anonymous_access_supported"`
-	WalletInitiatedAuthFlowSupported           bool          `json:"wallet_initiated_auth_flow_supported"`
-	SignedCredentialOfferSupported             bool          `json:"signed_credential_offer_supported"`
-	ClaimsEndpoint                             string        `json:"claims_endpoint"`
+	IssuerWellKnownURL                         string   `json:"issuer_well_known"`
+	ClientID                                   string   `json:"client_id"`
+	ClientSecretHandle                         string   `json:"client_secret_handle"`
+	ScopesSupported                            []string `json:"scopes_supported"`
+	GrantTypesSupported                        []string `json:"grant_types_supported"`
+	ResponseTypesSupported                     []string `json:"response_types_supported"`
+	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
+	EnableDynamicClientRegistration            bool     `json:"enable_dynamic_client_registration"`
+	EnableDiscoverableClientIDScheme           bool     `json:"enable_discoverable_client_id_scheme"`
+	PreAuthorizedGrantAnonymousAccessSupported bool     `json:"pre-authorized_grant_anonymous_access_supported"`
+	WalletInitiatedAuthFlowSupported           bool     `json:"wallet_initiated_auth_flow_supported"`
+	SignedCredentialOfferSupported             bool     `json:"signed_credential_offer_supported"`
+	ClaimsEndpoint                             string   `json:"claims_endpoint"`
 }
 
 // VCConfig describes how to sign verifiable credentials.

--- a/pkg/restapi/v1/oidc4ci/controller.go
+++ b/pkg/restapi/v1/oidc4ci/controller.go
@@ -844,7 +844,7 @@ func (c *Controller) OidcRegisterClient(e echo.Context, profileID string, profil
 
 	if client.Secret != nil {
 		resp.ClientSecret = lo.ToPtr(string(client.Secret))
-		resp.ClientSecretExpiresAt = lo.ToPtr(int(client.SecretExpiresAt.Unix()))
+		resp.ClientSecretExpiresAt = lo.ToPtr(int(client.SecretExpiresAt))
 	}
 
 	if client.Name != "" {

--- a/pkg/restapi/v1/oidc4ci/controller_test.go
+++ b/pkg/restapi/v1/oidc4ci/controller_test.go
@@ -2105,7 +2105,7 @@ func TestController_OidcRegisterClient(t *testing.T) {
 						Name:                    "client-name",
 						URI:                     "https://example.com",
 						Secret:                  []byte("secret"),
-						SecretExpiresAt:         time.Now().Add(5 * time.Minute),
+						SecretExpiresAt:         0,
 						RedirectURIs:            []string{"https://example.com/callback"},
 						GrantTypes:              []string{"authorization_code"},
 						ResponseTypes:           []string{"code"},


### PR DESCRIPTION
This PR fixes the following issues:

* OAuth client manager uses values for `grant_types_supported`, `response_types_supported` and `token_endpoint_auth_methods_supported` from issuer's profile (OIDCConfig property). It's wrong as these values are supposed to be used when making calls to issuer's OIDC provider. VCS acts as an OIDC provider as well (e.g. for wallet) but it should use its own values here depending on what is actually implemented and supported (e.g. for `grant_type` only `authorization_code` and `urn:ietf:params:oauth:grant-type:pre-authorized_code` are supported).
* Support for client secret expiration is not implemented properly (i.e. it doesn't make sense to issue client ID with secret that will expire in 5 min) - so, for now, proposal is to create clients with secrets that never expire.