### PR TITLE
fix: Don't use the strict flag for JSON schema validation

### DIFF
--- a/pkg/restapi/v1/issuer/controller_test.go
+++ b/pkg/restapi/v1/issuer/controller_test.go
@@ -1485,7 +1485,7 @@ func TestController_PrepareCredential(t *testing.T) {
 					Credential:              invalidVC,
 					Format:                  vcsverifiable.Ldp,
 					Retry:                   false,
-					EnforceStrictValidation: true,
+					EnforceStrictValidation: false,
 					CredentialTemplate: &profileapi.CredentialTemplate{
 						JSONSchema:   string(universityDegreeSchema),
 						JSONSchemaID: "https://trustbloc.com/universitydegree.schema.json",


### PR DESCRIPTION
The profile flag, "EnforceStrictValidation" should only be used to determine whether JSON-LD validation should be performed. JSON schema validation should be performed if a JSON schema is provided.