### PR TITLE
feat: trustlist v2 (with type filter)

### DIFF
--- a/component/profile/reader/file/reader.go
+++ b/component/profile/reader/file/reader.go
@@ -208,23 +208,25 @@ func NewVerifierReader(config *Config) (*VerifierReader, error) {
 	return &r, nil
 }
 
-func (p *VerifierReader) setTrustList(verifier *profileapi.Verifier) {
+func (p *VerifierReader) setTrustList(
+	verifier *profileapi.Verifier,
+) {
 	if verifier == nil || verifier.Checks == nil || len(createdIssuers) == 0 ||
 		len(verifier.Checks.Credential.IssuerTrustList) == 0 {
 		return
 	}
 
-	var updatedList []string
-	for _, item := range verifier.Checks.Credential.IssuerTrustList {
-		issuer, ok := createdIssuers[item]
+	updated := make(map[string]profileapi.TrustList)
+	for k, v := range verifier.Checks.Credential.IssuerTrustList {
+		issuer, ok := createdIssuers[k]
 		if !ok {
 			continue
 		}
 
-		updatedList = append(updatedList, issuer.SigningDID.DID)
+		updated[issuer.SigningDID.DID] = v
 	}
 
-	verifier.Checks.Credential.IssuerTrustList = updatedList
+	verifier.Checks.Credential.IssuerTrustList = updated
 }
 
 // GetProfile returns profile with given id.

--- a/pkg/profile/api.go
+++ b/pkg/profile/api.go
@@ -176,7 +176,12 @@ type CredentialChecks struct {
 	CredentialExpiry bool                   `json:"credentialExpiry,omitempty"`
 	Strict           bool                   `json:"strict,omitempty"`
 	LinkedDomain     bool                   `json:"linkedDomain,omitempty"`
-	IssuerTrustList  []string               `json:"issuerTrustList,omitempty"`
+	IssuerTrustList  map[string]TrustList   `json:"issuerTrustList,omitempty"`
+}
+
+// TrustList contains list of configuration that verifier is trusted to accept.
+type TrustList struct {
+	CredentialTypes []string `json:"credentialTypes,omitempty"`
 }
 
 // SigningDID contains information about profile signing did.

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -81,12 +81,12 @@ func runBDDTests(tags, format string) int {
 }
 
 func InitializeTestSuite(ctx *godog.TestSuiteContext) {
-	//if os.Getenv("DISABLE_COMPOSITION") == "true" {
-	//	return
-	//}
-	//
-	//ctx.BeforeSuite(beforeSuiteHook)
-	//ctx.AfterSuite(afterSuiteHook)
+	if os.Getenv("DISABLE_COMPOSITION") == "true" {
+		return
+	}
+
+	ctx.BeforeSuite(beforeSuiteHook)
+	ctx.AfterSuite(afterSuiteHook)
 }
 
 func beforeSuiteHook() {

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -81,12 +81,12 @@ func runBDDTests(tags, format string) int {
 }
 
 func InitializeTestSuite(ctx *godog.TestSuiteContext) {
-	if os.Getenv("DISABLE_COMPOSITION") == "true" {
-		return
-	}
-
-	ctx.BeforeSuite(beforeSuiteHook)
-	ctx.AfterSuite(afterSuiteHook)
+	//if os.Getenv("DISABLE_COMPOSITION") == "true" {
+	//	return
+	//}
+	//
+	//ctx.BeforeSuite(beforeSuiteHook)
+	//ctx.AfterSuite(afterSuiteHook)
 }
 
 func beforeSuiteHook() {

--- a/test/bdd/features/oidc4vc_api.feature
+++ b/test/bdd/features/oidc4vc_api.feature
@@ -57,29 +57,36 @@ Feature: OIDC4VC REST API
 #     LDP issuer, LDP verifier, no limit disclosure and schema match in PD query.
       | i_myprofile_cmtr_p256_ldp/v1.0 | CrudeProductCredential     | crudeProductCredentialTemplateID | v_myprofile_ldp/v1.0 | lp403pb9-schema-match                        | schema_id                                                    |
 
-  Scenario: OIDC credential issuance and verification Pre Auth flow with trustlist (Success)
+  Scenario Outline: OIDC credential issuance and verification Pre Auth flow with trustlist (Success)
     Given Organization "test_org" has been authorized with client id "f13d1va9lp403pb9lyj89vk55" and secret "ejqxi9jb1vew2jbdnogpjcgrz"
-    And   Issuer with id "bank_issuer_sdjwt_v5/v1.0" is authorized as a Profile user
-    And   User holds credential "CrudeProductCredential" with templateID "crudeProductCredentialTemplateID"
+    And   Issuer with id "<issuerProfile>" is authorized as a Profile user
+    And   User holds credential "<credentialType>" with templateID "<credentialTemplate>"
 
     When User interacts with Wallet to initiate credential issuance using pre authorization code flow
     Then credential is issued
-    Then User interacts with Verifier and initiate OIDC4VP interaction under "v_myprofile_jwt_whitelist/v1.0" profile for organization "test_org" with presentation definition ID "3c8b1d9a-limit-disclosure-optional-fields" and fields "unit_of_measure_barrel,api_gravity,category,supplier_address"
+    Then User interacts with Verifier and initiate OIDC4VP interaction under "<verifierProfile>" profile for organization "test_org" with presentation definition ID "<presentationDefinitionID>" and fields "<fields>"
     And Verifier from organization "test_org" retrieves interactions claims
     Then we wait 2 seconds
     And Verifier form organization "test_org" requests deleted interactions claims
+    Examples:
+      | issuerProfile             | credentialType             | credentialTemplate               | verifierProfile                | presentationDefinitionID                  | fields                                                       |
+      | bank_issuer_sdjwt_v5/v1.0 | CrudeProductCredential     | crudeProductCredentialTemplateID | v_myprofile_jwt_whitelist/v1.0 | 3c8b1d9a-limit-disclosure-optional-fields | unit_of_measure_barrel,api_gravity,category,supplier_address |
+      | bank_issuer/v1.0          | UniversityDegreeCredential | universityDegreeTemplateID       | v_myprofile_jwt_whitelist/v1.0 | 32f54163-no-limit-disclosure-single-field | degree_type_id                                               |
 
 # Error cases
 
-  Scenario: OIDC credential issuance and verification Pre Auth flow with trustlist (Fail)
+  Scenario Outline: OIDC credential issuance and verification Pre Auth flow with trustlist (Fail)
     Given Organization "test_org" has been authorized with client id "f13d1va9lp403pb9lyj89vk55" and secret "ejqxi9jb1vew2jbdnogpjcgrz"
-    And   Issuer with id "bank_issuer/v1.0" is authorized as a Profile user
-    And   User holds credential "CrudeProductCredential" with templateID "crudeProductCredentialTemplateID"
+    And   Issuer with id "<issuerProfile>" is authorized as a Profile user
+    And   User holds credential "<credentialType>" with templateID "<credentialTemplate>"
 
     When User interacts with Wallet to initiate credential issuance using pre authorization code flow
     Then credential is issued
-    Then User interacts with Verifier and initiate OIDC4VP interaction under "v_myprofile_jwt_whitelist/v1.0" profile for organization "test_org" with presentation definition ID "3c8b1d9a-limit-disclosure-optional-fields" and fields "unit_of_measure_barrel,api_gravity,category,supplier_address" and receives "is not a member of trustlist" error
-
+    Then User interacts with Verifier and initiate OIDC4VP interaction under "<verifierProfile>" profile for organization "test_org" with presentation definition ID "<presentationDefinitionID>" and fields "<fields>" and receives "is not a member of trustlist" error
+    Examples:
+      | issuerProfile                  | credentialType             | credentialTemplate              | verifierProfile                | presentationDefinitionID                     | fields                                                    |
+      | bank_issuer_sdjwt_v5/v1.0      | UniversityDegreeCredential | universityDegreeTemplateID      | v_myprofile_jwt_whitelist/v1.0 | 32f54163-no-limit-disclosure-single-field    | degree_type_id                                            |
+      | i_myprofile_ud_es256k_jwt/v1.0 | PermanentResidentCard      | permanentResidentCardTemplateID | v_myprofile_jwt_whitelist/v1.0 | 32f54163-no-limit-disclosure-optional-fields | lpr_category_id,registration_city,commuter_classification |
 
   Scenario: OIDC credential issuance and verification Pre Auth flow (Invalid Claims)
     Given Organization "test_org" has been authorized with client id "f13d1va9lp403pb9lyj89vk55" and secret "ejqxi9jb1vew2jbdnogpjcgrz"

--- a/test/bdd/fixtures/profile/profiles.json
+++ b/test/bdd/fixtures/profile/profiles.json
@@ -1930,9 +1930,14 @@
             "format": [
               "jwt"
             ],
-            "issuerTrustList" : [
-              "bank_issuer_sdjwt_v5"
-            ],
+            "issuerTrustList": {
+              "bank_issuer" : {},
+              "bank_issuer_sdjwt_v5": {
+                "credentialTypes": [
+                  "CrudeProductCredential"
+                ]
+              }
+            },
             "proof": true,
             "status": true,
             "strict": true


### PR DESCRIPTION
Signed-off-by: Stas D <stanislav.dmytryshyn@securekey.com>
if issuer signing did exists in trust list  and credentialsTypes are empty  = **we trust to all credentials types from this issuer**.
if issuer signing did exists in trust list  and credentialsTypes are not empty  = **we trust to only specified credentialTypes from this issuer**.