### PR TITLE
fix: concurrency panic drop claims keys

### DIFF
--- a/pkg/observability/tracing/wrappers/verifypresentation/verifypresentation_wrapper.go
+++ b/pkg/observability/tracing/wrappers/verifypresentation/verifypresentation_wrapper.go
@@ -10,7 +10,6 @@ package verifypresentation
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/trustbloc/vc-go/verifiable"
 	"go.opentelemetry.io/otel/attribute"
@@ -51,21 +50,8 @@ func (w *Wrapper) VerifyPresentation(
 
 	res, err := w.svc.VerifyPresentation(ctx, presentation, opts, profile)
 	if err != nil {
-		w.setClaimKeys(span)
 		return nil, err
 	}
 
-	w.setClaimKeys(span)
 	return res, nil
-}
-
-func (w *Wrapper) setClaimKeys(span trace.Span) {
-	svc, ok := w.svc.(*verifypresentation.Service)
-	if !ok {
-		return
-	}
-
-	for id, claimKeys := range svc.GetClaimKeys() {
-		span.SetAttributes(attribute.StringSlice(fmt.Sprintf("claim_keys_%s", id), claimKeys))
-	}
 }

--- a/pkg/service/verifypresentation/verifypresentation_service.go
+++ b/pkg/service/verifypresentation/verifypresentation_service.go
@@ -43,7 +43,6 @@ type Service struct {
 	vdr            vdrapi.Registry
 	documentLoader ld.DocumentLoader
 	vcVerifier     vcVerifier
-	claimKeys      map[string][]string
 }
 
 func New(config *Config) *Service {
@@ -51,7 +50,6 @@ func New(config *Config) *Service {
 		vdr:            config.VDR,
 		documentLoader: config.DocumentLoader,
 		vcVerifier:     config.VcVerifier,
-		claimKeys:      map[string][]string{},
 	}
 }
 
@@ -67,8 +65,6 @@ func (s *Service) VerifyPresentation( //nolint:funlen,gocognit
 	defer func() {
 		logger.Debugc(ctx, "VerifyPresentation", log.WithDuration(time.Since(startTime)))
 	}()
-
-	s.claimKeys = map[string][]string{}
 
 	var result []PresentationVerificationCheckResult
 
@@ -173,7 +169,9 @@ func (s *Service) VerifyPresentation( //nolint:funlen,gocognit
 }
 
 func (s *Service) checkCredentialStrict(
-	ctx context.Context, credentials []*verifiable.Credential) error { //nolint:gocognit
+	ctx context.Context,
+	credentials []*verifiable.Credential,
+) error { //nolint:gocognit
 	for _, cred := range credentials {
 		//TODO: check how bug fixed will affects other code.
 		// previously if credential was not in format of *verifiable.Credential validations was ignored
@@ -201,8 +199,6 @@ func (s *Service) checkCredentialStrict(
 				claimKeys = append(claimKeys, k)
 			}
 		}
-
-		s.claimKeys[credContents.ID] = claimKeys
 
 		if logger.IsEnabled(log.DEBUG) {
 			logger.Debugc(ctx, "verifier strict validation check",
@@ -382,9 +378,4 @@ func (s *Service) extractCredentialStatus(
 	credContents := cred.Contents()
 
 	return credContents.Status, credContents.Issuer
-}
-
-// GetClaimKeys returns credential claim keys.
-func (s *Service) GetClaimKeys() map[string][]string {
-	return s.claimKeys
 }

--- a/pkg/service/verifypresentation/verifypresentation_service_test.go
+++ b/pkg/service/verifypresentation/verifypresentation_service_test.go
@@ -55,7 +55,6 @@ func TestNew(t *testing.T) {
 				vdr:            &mockvdr.VDRegistry{},
 				documentLoader: testutil.DocumentLoader(t),
 				vcVerifier:     NewMockVcVerifier(gomock.NewController(t)),
-				claimKeys:      map[string][]string{},
 			},
 		},
 	}
@@ -920,7 +919,6 @@ func TestCredentialStrict(t *testing.T) {
 		DocumentLoader: ld.NewDefaultDocumentLoader(http.DefaultClient),
 	})
 	assert.NoError(t, s.checkCredentialStrict(context.TODO(), []*verifiable.Credential{l}))
-	assert.ElementsMatch(t, []string{"type", "degree"}, s.GetClaimKeys()["credentialID"])
 }
 
 func TestCheckTrustList(t *testing.T) {

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/trustbloc/logutil-go v1.0.0-rc1
 	github.com/trustbloc/vc-go v1.0.3-0.20230927100750-6e0ff8399468
 	github.com/trustbloc/vcs v0.1.9-0.20230210204445-f2870a36f0ea
-	github.com/trustbloc/vcs/component/wallet-cli v0.0.0-20230710195911-02aad4f0fcec
+	github.com/trustbloc/vcs/component/wallet-cli v0.0.0-20231003142611-b9399c5814c2
 	github.com/trustbloc/vcs/test/stress v0.0.0-00010101000000-000000000000
 	go.uber.org/zap v1.23.0
 	golang.org/x/oauth2 v0.7.0


### PR DESCRIPTION
fatal error: concurrent map writes

goroutine 26200 [running]:
github.com/trustbloc/vcs/pkg/service/verifypresentation.(*Service).checkCredentialStrict(0xc00015b9c0, {0x2028368, 0xc005c7a810}, {0xc000302ba0, 0x1, 0xc003d39c40?})
	/go/src/github.com/trustbloc/vcs/.build/vcs/pkg/service/verifypresentation/verifypresentation_service.go:205 +0x1f7
github.com/trustbloc/vcs/pkg/service/verifypresentation.(*Service).VerifyPresentation(0xc00015b9c0, {0x2028368, 0xc005c7a810}, 0xc007628f20, 0x0?, 0xc0072562c0)