### PR TITLE
fix: claims keys concurrency

### DIFF
--- a/pkg/observability/tracing/wrappers/verifypresentation/verifypresentation_wrapper_test.go
+++ b/pkg/observability/tracing/wrappers/verifypresentation/verifypresentation_wrapper_test.go
@@ -28,6 +28,6 @@ func TestWrapper_VerifyPresentation(t *testing.T) {
 
 	w := Wrap(svc, trace.NewNoopTracerProvider().Tracer(""))
 
-	_, err := w.VerifyPresentation(context.Background(), &verifiable.Presentation{}, &verifypresentation.Options{}, &profileapi.Verifier{})
+	_, _, err := w.VerifyPresentation(context.Background(), &verifiable.Presentation{}, &verifypresentation.Options{}, &profileapi.Verifier{})
 	require.NoError(t, err)
 }

--- a/pkg/restapi/v1/verifier/controller.go
+++ b/pkg/restapi/v1/verifier/controller.go
@@ -285,7 +285,7 @@ func (c *Controller) verifyPresentation(ctx context.Context, body *VerifyPresent
 		return nil, resterr.NewValidationError(resterr.InvalidValue, "presentation", err)
 	}
 
-	verRes, err := c.verifyPresentationSvc.VerifyPresentation(ctx, presentation,
+	verRes, _, err := c.verifyPresentationSvc.VerifyPresentation(ctx, presentation,
 		getVerifyPresentationOptions(body.Options), profile)
 	if err != nil {
 		return nil, resterr.NewSystemError(verifyCredentialSvcComponent, "VerifyCredential", err)

--- a/pkg/restapi/v1/verifier/controller_test.go
+++ b/pkg/restapi/v1/verifier/controller_test.go
@@ -296,7 +296,7 @@ func TestController_PostVerifyPresentation(t *testing.T) {
 	mockVerifyPresSvc.EXPECT().
 		VerifyPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().
-		Return([]verifypresentation.PresentationVerificationCheckResult{{}}, nil)
+		Return([]verifypresentation.PresentationVerificationCheckResult{{}}, nil, nil)
 
 	mockProfileSvc.EXPECT().GetProfile(profileID, profileVersion).AnyTimes().
 		Return(&profileapi.Verifier{
@@ -343,7 +343,7 @@ func TestController_VerifyPresentation(t *testing.T) {
 	mockVerifyPresentationSvc.EXPECT().
 		VerifyPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().
-		Return(verificationResult, nil)
+		Return(verificationResult, nil, nil)
 
 	mockProfileSvc.EXPECT().GetProfile(profileID, profileVersion).AnyTimes().
 		Return(&profileapi.Verifier{
@@ -433,7 +433,7 @@ func TestController_VerifyPresentation(t *testing.T) {
 					failedMockVerifyPresSvc.EXPECT().
 						VerifyPresentation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						AnyTimes().
-						Return(nil, errors.New("some error"))
+						Return(nil, nil, errors.New("some error"))
 					return failedMockVerifyPresSvc
 				},
 			},

--- a/pkg/service/oidc4vp/oidc4vp_service.go
+++ b/pkg/service/oidc4vp/oidc4vp_service.go
@@ -76,7 +76,10 @@ type presentationVerifier interface {
 		ctx context.Context,
 		presentation *verifiable.Presentation,
 		opts *verifypresentation.Options,
-		profile *profileapi.Verifier) ([]verifypresentation.PresentationVerificationCheckResult, error)
+		profile *profileapi.Verifier,
+	) (
+		[]verifypresentation.PresentationVerificationCheckResult, map[string][]string, error,
+	)
 }
 
 type RequestObjectClaims struct {
@@ -296,7 +299,7 @@ func (s *Service) verifyTokens(
 				return
 			}
 
-			vr, innerErr := s.presentationVerifier.VerifyPresentation(ctx, token.Presentation, &verifypresentation.Options{
+			vr, _, innerErr := s.presentationVerifier.VerifyPresentation(ctx, token.Presentation, &verifypresentation.Options{
 				Domain:    token.ClientID,
 				Challenge: token.Nonce,
 			}, profile)

--- a/pkg/service/oidc4vp/oidc4vp_service_test.go
+++ b/pkg/service/oidc4vp/oidc4vp_service_test.go
@@ -577,7 +577,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 		errPresentationVerifier := NewMockPresentationVerifier(gomock.NewController(t))
 		errPresentationVerifier.EXPECT().VerifyPresentation(
 			context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
-			Return(nil, errors.New("verification failed"))
+			Return(nil, nil, errors.New("verification failed"))
 		withError := oidc4vp.NewService(&oidc4vp.Config{
 			EventSvc:             &mockEvent{},
 			EventTopic:           spi.VerifierEventTopic,

--- a/pkg/service/oidc4vp/oidc4vp_service_test.go
+++ b/pkg/service/oidc4vp/oidc4vp_service_test.go
@@ -290,7 +290,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 	}, nil)
 
 	presentationVerifier.EXPECT().VerifyPresentation(context.Background(), gomock.Any(), gomock.Any(), gomock.Any()).
-		AnyTimes().Return(nil, nil)
+		AnyTimes().Return(nil, nil, nil)
 
 	t.Run("Success", func(t *testing.T) {
 		err := s.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",

--- a/pkg/service/verifypresentation/api.go
+++ b/pkg/service/verifypresentation/api.go
@@ -31,5 +31,5 @@ type ServiceInterface interface {
 		presentation *verifiable.Presentation,
 		opts *Options,
 		profile *profileapi.Verifier,
-	) ([]PresentationVerificationCheckResult, error)
+	) ([]PresentationVerificationCheckResult, map[string][]string, error)
 }

--- a/pkg/service/verifypresentation/verifypresentation_service_test.go
+++ b/pkg/service/verifypresentation/verifypresentation_service_test.go
@@ -55,7 +55,6 @@ func TestNew(t *testing.T) {
 				vdr:            &mockvdr.VDRegistry{},
 				documentLoader: testutil.DocumentLoader(t),
 				vcVerifier:     NewMockVcVerifier(gomock.NewController(t)),
-				claimKeys:      map[string][]string{},
 			},
 		},
 	}
@@ -386,7 +385,7 @@ func TestService_VerifyPresentation(t *testing.T) {
 				vcVerifier:     tt.fields.getVcVerifier(),
 			}
 
-			got, err := s.VerifyPresentation(context.Background(), tt.args.getPresentation(), tt.args.opts, tt.args.profile)
+			got, _, err := s.VerifyPresentation(context.Background(), tt.args.getPresentation(), tt.args.opts, tt.args.profile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("VerifyPresentation() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -919,8 +918,9 @@ func TestCredentialStrict(t *testing.T) {
 	s := New(&Config{
 		DocumentLoader: ld.NewDefaultDocumentLoader(http.DefaultClient),
 	})
-	assert.NoError(t, s.checkCredentialStrict(context.TODO(), []*verifiable.Credential{l}))
-	assert.ElementsMatch(t, []string{"type", "degree"}, s.GetClaimKeys()["credentialID"])
+	claimKeys, err := s.checkCredentialStrict(context.TODO(), []*verifiable.Credential{l})
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"type", "degree"}, claimKeys["credentialID"])
 }
 
 func TestCheckTrustList(t *testing.T) {

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -16,9 +16,10 @@ if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/profile/reader/file ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/event ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/healthchecks ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/credentialstatus ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/oidc/fosite ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/profile/reader/file ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/event ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/healthchecks ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/credentialstatus ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/oidc/fosite ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
+wait

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -16,10 +16,9 @@ if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/profile/reader/file ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/event ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/healthchecks ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/credentialstatus ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/oidc/fosite ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m &
-wait
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/profile/reader/file ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/event ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/healthchecks ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/credentialstatus ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/oidc/fosite ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/trustbloc/logutil-go v1.0.0-rc1
 	github.com/trustbloc/vc-go v1.0.3-0.20230927100750-6e0ff8399468
 	github.com/trustbloc/vcs v0.1.9-0.20230210204445-f2870a36f0ea
-	github.com/trustbloc/vcs/component/wallet-cli v0.0.0-20230710195911-02aad4f0fcec
+	github.com/trustbloc/vcs/component/wallet-cli v0.0.0-20231003142611-b9399c5814c2
 	github.com/trustbloc/vcs/test/stress v0.0.0-00010101000000-000000000000
 	go.uber.org/zap v1.23.0
 	golang.org/x/oauth2 v0.7.0


### PR DESCRIPTION
fatal error: concurrent map writes

goroutine 26200 [running]:
github.com/trustbloc/vcs/pkg/service/verifypresentation.(*Service).checkCredentialStrict(0xc00015b9c0, {0x2028368, 0xc005c7a810}, {0xc000302ba0, 0x1, 0xc003d39c40?})
/go/src/github.com/trustbloc/vcs/.build/vcs/pkg/service/verifypresentation/verifypresentation_service.go:205 +0x1f7
github.com/trustbloc/vcs/pkg/service/verifypresentation.(*Service).VerifyPresentation(0xc00015b9c0, {0x2028368, 0xc005c7a810}, 0xc007628f20, 0x0?, 0xc0072562c0)

