### PR TITLE
feat: Add routing key to event

### DIFF
--- a/component/credentialstatus/credentialstatus_service.go
+++ b/component/credentialstatus/credentialstatus_service.go
@@ -398,9 +398,15 @@ func (s *Service) createStatusUpdatedEvent(
 		return nil, fmt.Errorf("unable to marshal UpdateCredentialStatusEventPayload: %w", err)
 	}
 
-	return spi.NewEventWithPayload(
+	evt := spi.NewEventWithPayload(
 		uuid.NewString(),
 		credentialStatusEventSource,
 		spi.CredentialStatusStatusUpdated,
-		payload), nil
+		payload)
+
+	// Set the routing key to the CSL URL to give the event bus a hint
+	// on how/where to route the event.
+	evt.RoutingKey = cslURL
+
+	return evt, nil
 }

--- a/pkg/event/spi/spi.go
+++ b/pkg/event/spi/spi.go
@@ -82,6 +82,9 @@ type Event struct {
 
 	// Tracing defines tracing information(optional).
 	Tracing string `json:"tracing,omitempty"`
+
+	// RoutingKey is an optional key that is used by the event bus to determining how/where to route the event.
+	RoutingKey string `json:"-"`
 }
 
 // Copy an event.


### PR DESCRIPTION
RoutingKey is an optional key that is used by the event bus to determining how/where to route the event.

Set the routing key to be the CSL URL for credential status update events.