### PR TITLE
feat: Update trust-registry issuer endpoint

### DIFF
--- a/pkg/service/trustregistry/api.go
+++ b/pkg/service/trustregistry/api.go
@@ -31,8 +31,9 @@ type CredentialMetadata struct {
 
 // IssuancePolicyEvaluationRequest is a request payload for issuance policy evaluation service.
 type IssuancePolicyEvaluationRequest struct {
-	AttestationVC *string `json:"attestation_vc,omitempty"`
-	IssuerDID     string  `json:"issuer_did"`
+	CredentialTypes []string  `json:"credential_types"`
+	AttestationVC   *[]string `json:"attestation_vc,omitempty"`
+	IssuerDID       string    `json:"issuer_did"`
 }
 
 // PresentationPolicyEvaluationRequest is a request payload for presentation policy evaluation service.

--- a/pkg/service/trustregistry/trustregistry_service_test.go
+++ b/pkg/service/trustregistry/trustregistry_service_test.go
@@ -738,6 +738,11 @@ func createIssuerProfile(t *testing.T) *profileapi.Issuer {
 				Enabled: true,
 			},
 		},
+		CredentialTemplates: []*profileapi.CredentialTemplate{
+			{
+				Type: "VerifiedDocument",
+			},
+		},
 	}
 
 	return profile

--- a/test/bdd/trustregistry/models.go
+++ b/test/bdd/trustregistry/models.go
@@ -8,8 +8,9 @@ package main
 
 // IssuerIssuanceRequest is a model for issuer issuance policy evaluation.
 type IssuerIssuanceRequest struct {
-	AttestationVC *string `json:"attestation_vc,omitempty"`
-	IssuerDID     string  `json:"issuer_did"`
+	AttestationVC   *[]string `json:"attestation_vc,omitempty"`
+	CredentialTypes []string  `json:"credential_types"`
+	IssuerDID       string    `json:"issuer_did"`
 }
 
 // VerifierPresentationRequest is a model for verifier presentation policy evaluation.

--- a/test/bdd/trustregistry/server.go
+++ b/test/bdd/trustregistry/server.go
@@ -54,9 +54,9 @@ func (s *server) evaluateIssuerIssuancePolicy(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if request.AttestationVC == nil || len(*request.AttestationVC) == 0 {
+	if len(request.CredentialTypes) == 0 {
 		s.writeResponse(
-			w, http.StatusBadRequest, "no attestation vc supplied")
+			w, http.StatusBadRequest, "no credential types supplied")
 
 		return
 	}


### PR DESCRIPTION
The trust-registry issuer endpoint request now includes an array of attestations and an array or credential types.