### PR TITLE
feat: Additional fields in verifier oidc events payload

### DIFF
--- a/pkg/service/oidc4vp/api.go
+++ b/pkg/service/oidc4vp/api.go
@@ -65,20 +65,28 @@ type ServiceInterface interface {
 }
 
 type EventPayload struct {
-	WebHook                  string  `json:"webHook,omitempty"`
-	ProfileID                string  `json:"profileID,omitempty"`
-	ProfileVersion           string  `json:"profileVersion,omitempty"`
-	OrgID                    string  `json:"orgID,omitempty"`
-	PresentationDefinitionID string  `json:"presentationDefinitionID,omitempty"`
-	Filter                   *Filter `json:"filter,omitempty"`
-	AuthorizationRequest     string  `json:"authorizationRequest,omitempty"`
-	Error                    string  `json:"error,omitempty"`
-	ErrorCode                string  `json:"errorCode,omitempty"`
-	ErrorComponent           string  `json:"errorComponent,omitempty"`
+	WebHook                  string                    `json:"webHook,omitempty"`
+	ProfileID                string                    `json:"profileID,omitempty"`
+	ProfileVersion           string                    `json:"profileVersion,omitempty"`
+	OrgID                    string                    `json:"orgID,omitempty"`
+	PresentationDefinitionID string                    `json:"presentationDefinitionID,omitempty"`
+	Filter                   *Filter                   `json:"filter,omitempty"`
+	AuthorizationRequest     string                    `json:"authorizationRequest,omitempty"`
+	Error                    string                    `json:"error,omitempty"`
+	ErrorCode                string                    `json:"errorCode,omitempty"`
+	ErrorComponent           string                    `json:"errorComponent,omitempty"`
+	Credentials              []*CredentialEventPayload `json:"credentials,omitempty"`
 }
 
 type Filter struct {
 	Fields []string `json:"fields"`
+}
+
+type CredentialEventPayload struct {
+	ID        string   `json:"id,omitempty"`
+	Types     []string `json:"types,omitempty"`
+	SubjectID string   `json:"subjectID,omitempty"`
+	IssuerID  string   `json:"issuerID,omitempty"`
 }
 
 type TxNonceStore txNonceStore

--- a/pkg/service/oidc4vp/oidc4vp_service.go
+++ b/pkg/service/oidc4vp/oidc4vp_service.go
@@ -451,16 +451,25 @@ func (s *Service) VerifyOIDCVerifiablePresentation(
 		return err
 	}
 
-	err = s.extractClaimData(ctx, tx, authResponse, profile, verifiedPresentations)
+	receivedClaims, err := s.extractClaimData(ctx, tx, authResponse, profile, verifiedPresentations)
 	if err != nil {
 		s.sendFailedTransactionEvent(ctx, tx, profile, err)
 
 		return err
 	}
 
+	err = s.transactionManager.StoreReceivedClaims(tx.ID, receivedClaims)
+	if err != nil {
+		s.sendFailedTransactionEvent(ctx, tx, profile, err)
+
+		return resterr.NewSystemError(resterr.VerifierTxnMgrComponent, "store-received-claims",
+			fmt.Errorf("store received claims: %w", err))
+	}
+
 	logger.Debugc(ctx, "extractClaimData claims stored")
 
-	if err = s.sendTxEvent(ctx, spi.VerifierOIDCInteractionSucceeded, tx, profile); err != nil {
+	err = s.sendOIDCInteractionEvent(ctx, spi.VerifierOIDCInteractionSucceeded, tx, profile, receivedClaims)
+	if err != nil {
 		return err
 	}
 
@@ -578,7 +587,8 @@ func (s *Service) RetrieveClaims(
 
 	logger.Debugc(ctx, "RetrieveClaims succeed")
 
-	if err := s.sendTxEvent(ctx, spi.VerifierOIDCInteractionClaimsRetrieved, tx, profile); err != nil {
+	err := s.sendOIDCInteractionEvent(ctx, spi.VerifierOIDCInteractionClaimsRetrieved, tx, profile, tx.ReceivedClaims)
+	if err != nil {
 		logger.Warnc(ctx, "Failed to send event", log.WithError(err))
 	}
 
@@ -610,7 +620,7 @@ func (s *Service) extractClaimData(
 	authResponse *AuthorizationResponseParsed,
 	profile *profileapi.Verifier,
 	verifiedPresentations map[string]*ProcessedVPToken,
-) error {
+) (*ReceivedClaims, error) {
 	var presentations []*verifiable.Presentation
 
 	for _, token := range authResponse.VPTokens {
@@ -620,7 +630,7 @@ func (s *Service) extractClaimData(
 	}
 	diVerifier, err := s.getDataIntegrityVerifier()
 	if err != nil {
-		return resterr.NewSystemError(resterr.VerifierDataIntegrityVerifier, "create-verifier",
+		return nil, resterr.NewSystemError(resterr.VerifierDataIntegrityVerifier, "create-verifier",
 			fmt.Errorf("get data integrity verifier: %w", err))
 	}
 
@@ -640,7 +650,7 @@ func (s *Service) extractClaimData(
 
 	matchedCredentials, err := tx.PresentationDefinition.Match(presentations, s.documentLoader, opts...)
 	if err != nil {
-		return resterr.NewCustomError(resterr.PresentationDefinitionMismatch,
+		return nil, resterr.NewCustomError(resterr.PresentationDefinitionMismatch,
 			fmt.Errorf("presentation definition match: %w", err))
 	}
 
@@ -651,12 +661,12 @@ func (s *Service) extractClaimData(
 			token, ok := verifiedPresentations[mc.PresentationID]
 			if !ok {
 				// this should never happen
-				return fmt.Errorf("missing verified presentation ID: %s", mc.PresentationID)
+				return nil, fmt.Errorf("missing verified presentation ID: %s", mc.PresentationID)
 			}
 
 			err = checkVCSubject(mc.Credential, token)
 			if err != nil {
-				return fmt.Errorf("extractClaimData vc subject: %w", err)
+				return nil, fmt.Errorf("extractClaimData vc subject: %w", err)
 			}
 
 			logger.Debugc(ctx, "vc subject verified")
@@ -670,13 +680,7 @@ func (s *Service) extractClaimData(
 		Credentials:       storeCredentials,
 	}
 
-	err = s.transactionManager.StoreReceivedClaims(tx.ID, receivedClaims)
-	if err != nil {
-		return resterr.NewSystemError(resterr.VerifierTxnMgrComponent, "store-received-claims",
-			fmt.Errorf("store received claims: %w", err))
-	}
-
-	return nil
+	return receivedClaims, nil
 }
 
 func checkVCSubject(cred *verifiable.Credential, token *ProcessedVPToken) error {
@@ -843,6 +847,49 @@ func (s *Service) createRequestObject(
 			presentationDefinition,
 		}},
 	}
+}
+
+func (s *Service) sendOIDCInteractionEvent(
+	ctx context.Context,
+	eventType spi.EventType,
+	tx *Transaction,
+	profile *profileapi.Verifier,
+	receivedClaims *ReceivedClaims,
+) error {
+	ep := createTxEventPayload(tx, profile)
+
+	for _, c := range receivedClaims.Credentials {
+		cred := c.Contents()
+
+		subjectID, err := verifiable.SubjectID(cred.Subject)
+		if err != nil {
+			logger.Warnc(ctx, "Unable to extract ID from credential subject: %w", log.WithError(err))
+		}
+
+		var issuerID string
+		if cred.Issuer != nil {
+			issuerID = cred.Issuer.ID
+		}
+
+		ep.Credentials = append(ep.Credentials, &CredentialEventPayload{
+			ID:        cred.ID,
+			Types:     cred.Types,
+			IssuerID:  issuerID,
+			SubjectID: subjectID,
+		})
+	}
+
+	event, err := CreateEvent(eventType, tx.ID, ep)
+	if err != nil {
+		return fmt.Errorf("create OIDC verifier event: %w", err)
+	}
+
+	err = s.eventSvc.Publish(ctx, s.eventTopic, event)
+	if err != nil {
+		return fmt.Errorf("send OIDC verifier event: %w", err)
+	}
+
+	return nil
 }
 
 func getScope(customScopes []string) string {

--- a/pkg/service/oidc4vp/oidc4vp_service_test.go
+++ b/pkg/service/oidc4vp/oidc4vp_service_test.go
@@ -688,7 +688,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 	})
 
 	t.Run("Invalid _scope 3", func(t *testing.T) {
-		err := s.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
+		err = s.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
 			&oidc4vp.AuthorizationResponseParsed{
 				CustomScopeClaims: map[string]oidc4vp.Claims{
 					customScope: {},
@@ -714,7 +714,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 			DocumentLoader:       loader,
 		})
 
-		err := withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
+		err = withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
 			&oidc4vp.AuthorizationResponseParsed{
 				CustomScopeClaims: nil,
 				VPTokens: []*oidc4vp.ProcessedVPToken{{
@@ -742,7 +742,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 			TrustRegistryService: trustRegistry,
 		})
 
-		err := withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
+		err = withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
 			&oidc4vp.AuthorizationResponseParsed{
 				CustomScopeClaims: nil,
 				VPTokens: []*oidc4vp.ProcessedVPToken{{
@@ -756,7 +756,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 	})
 
 	t.Run("Match failed", func(t *testing.T) {
-		err := s.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
+		err = s.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
 			&oidc4vp.AuthorizationResponseParsed{
 				CustomScopeClaims: nil,
 				VPTokens: []*oidc4vp.ProcessedVPToken{{
@@ -790,7 +790,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 			TrustRegistryService: trustRegistry,
 		})
 
-		err := withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
+		err = withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
 			&oidc4vp.AuthorizationResponseParsed{
 				CustomScopeClaims: nil,
 				VPTokens: []*oidc4vp.ProcessedVPToken{{
@@ -819,7 +819,7 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 			TrustRegistryService: errTrustRegistry,
 		})
 
-		err := withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
+		err = withError.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
 			&oidc4vp.AuthorizationResponseParsed{
 				CustomScopeClaims: nil,
 				VPTokens: []*oidc4vp.ProcessedVPToken{{
@@ -830,6 +830,63 @@ func TestService_VerifyOIDCVerifiablePresentation(t *testing.T) {
 				}}})
 
 		require.Contains(t, err.Error(), "check policy")
+	})
+
+	t.Run("Event publish error", func(t *testing.T) {
+		txManager2 := NewMockTransactionManager(gomock.NewController(t))
+
+		txManager2.EXPECT().GetByOneTimeToken("nonce1").AnyTimes().Return(&oidc4vp.Transaction{
+			ID:                     "txID1",
+			ProfileID:              profileID,
+			ProfileVersion:         profileVersion,
+			PresentationDefinition: pd,
+		}, true, nil)
+
+		txManager2.EXPECT().StoreReceivedClaims(oidc4vp.TxID("txID1"), gomock.Any()).Times(1)
+
+		errExpected := errors.New("injected publish error")
+
+		mockEventSvc := NewMockeventService(gomock.NewController(t))
+		mockEventSvc.EXPECT().Publish(gomock.Any(), spi.VerifierEventTopic, gomock.Any()).Times(2).
+			DoAndReturn(
+				func(ctx context.Context, topic string, messages ...*spi.Event) error {
+					require.Len(t, messages, 1)
+
+					switch messages[0].Type { //nolint:exhaustive
+					case spi.VerifierOIDCInteractionQRScanned:
+						return nil
+					case spi.VerifierOIDCInteractionSucceeded:
+						return errExpected
+					default:
+						return fmt.Errorf("unexpected event type: %s", messages[0].Type)
+					}
+				},
+			)
+
+		s2 := oidc4vp.NewService(&oidc4vp.Config{
+			EventSvc:             mockEventSvc,
+			EventTopic:           spi.VerifierEventTopic,
+			TransactionManager:   txManager2,
+			PresentationVerifier: presentationVerifier,
+			ProfileService:       profileService,
+			DocumentLoader:       loader,
+			VDR:                  vdr,
+			TrustRegistryService: trustRegistry,
+		})
+
+		err = s2.VerifyOIDCVerifiablePresentation(context.Background(), "txID1",
+			&oidc4vp.AuthorizationResponseParsed{
+				CustomScopeClaims: nil,
+				VPTokens: []*oidc4vp.ProcessedVPToken{{
+					Nonce:         "nonce1",
+					Presentation:  vp,
+					SignerDIDID:   issuer,
+					VpTokenFormat: vcsverifiable.Jwt,
+				}},
+			},
+		)
+
+		require.ErrorContains(t, err, errExpected.Error())
 	})
 }
 
@@ -884,7 +941,7 @@ func TestService_RetrieveClaims(t *testing.T) {
 	t.Run("Success JWT with custom claims", func(t *testing.T) {
 		mockEventSvc := NewMockeventService(gomock.NewController(t))
 		mockEventSvc.EXPECT().Publish(gomock.Any(), spi.VerifierEventTopic, gomock.Any()).DoAndReturn(
-			expectedPublishEventFunc(t, spi.VerifierOIDCInteractionClaimsRetrieved),
+			expectedPublishEventFunc(t, spi.VerifierOIDCInteractionClaimsRetrieved, nil),
 		)
 
 		svc := oidc4vp.NewService(&oidc4vp.Config{EventSvc: mockEventSvc, EventTopic: spi.VerifierEventTopic})
@@ -926,7 +983,7 @@ func TestService_RetrieveClaims(t *testing.T) {
 	t.Run("Success JsonLD without custom claims", func(t *testing.T) {
 		mockEventSvc := NewMockeventService(gomock.NewController(t))
 		mockEventSvc.EXPECT().Publish(gomock.Any(), spi.VerifierEventTopic, gomock.Any()).DoAndReturn(
-			expectedPublishEventFunc(t, spi.VerifierOIDCInteractionClaimsRetrieved),
+			expectedPublishEventFunc(t, spi.VerifierOIDCInteractionClaimsRetrieved, nil),
 		)
 
 		svc := oidc4vp.NewService(&oidc4vp.Config{EventSvc: mockEventSvc, EventTopic: spi.VerifierEventTopic})
@@ -956,7 +1013,7 @@ func TestService_RetrieveClaims(t *testing.T) {
 	t.Run("Empty claims", func(t *testing.T) {
 		mockEventSvc := NewMockeventService(gomock.NewController(t))
 		mockEventSvc.EXPECT().Publish(gomock.Any(), spi.VerifierEventTopic, gomock.Any()).DoAndReturn(
-			expectedPublishEventFunc(t, spi.VerifierOIDCInteractionClaimsRetrieved),
+			expectedPublishEventFunc(t, spi.VerifierOIDCInteractionClaimsRetrieved, nil),
 		)
 
 		svc := oidc4vp.NewService(&oidc4vp.Config{EventSvc: mockEventSvc, EventTopic: spi.VerifierEventTopic})
@@ -975,6 +1032,48 @@ func TestService_RetrieveClaims(t *testing.T) {
 			}}}, &profileapi.Verifier{})
 
 		require.Empty(t, claims)
+	})
+
+	t.Run("Success with publish event error", func(t *testing.T) {
+		mockEventSvc := NewMockeventService(gomock.NewController(t))
+		mockEventSvc.EXPECT().Publish(gomock.Any(), spi.VerifierEventTopic, gomock.Any()).DoAndReturn(
+			expectedPublishEventFunc(t, spi.VerifierOIDCInteractionClaimsRetrieved, errors.New("injected publish error")),
+		)
+
+		svc := oidc4vp.NewService(&oidc4vp.Config{EventSvc: mockEventSvc, EventTopic: spi.VerifierEventTopic})
+
+		jwtvc, err := verifiable.ParseCredential([]byte(sampleVCJWT),
+			verifiable.WithJSONLDDocumentLoader(loader),
+			verifiable.WithDisabledProofCheck())
+
+		require.NoError(t, err)
+
+		claims := svc.RetrieveClaims(context.Background(), &oidc4vp.Transaction{
+			ReceivedClaims: &oidc4vp.ReceivedClaims{
+				Credentials: map[string]*verifiable.Credential{
+					"id": jwtvc,
+				},
+				CustomScopeClaims: map[string]oidc4vp.Claims{
+					customScope: {
+						"key1": "value1",
+					},
+				},
+			},
+		}, &profileapi.Verifier{})
+
+		require.NotNil(t, claims)
+		subjects, ok := claims["http://example.gov/credentials/3732"].SubjectData.([]map[string]interface{})
+
+		require.True(t, ok)
+		require.Equal(t, "did:example:ebfeb1f712ebc6f1c276e12ec21", subjects[0]["id"])
+
+		require.NotEmpty(t, claims["http://example.gov/credentials/3732"].Issuer)
+		require.NotEmpty(t, claims["http://example.gov/credentials/3732"].IssuanceDate)
+		require.Empty(t, claims["http://example.gov/credentials/3732"].ExpirationDate)
+		require.Equal(t,
+			oidc4vp.CredentialMetadata{CustomClaims: map[string]oidc4vp.Claims{customScope: {"key1": "value1"}}},
+			claims["_scope"],
+		)
 	})
 }
 
@@ -1390,13 +1489,13 @@ func Test_GetSupportedVPFormats(t *testing.T) {
 
 type eventPublishFunc func(ctx context.Context, topic string, messages ...*spi.Event) error
 
-func expectedPublishEventFunc(t *testing.T, eventType spi.EventType) eventPublishFunc {
+func expectedPublishEventFunc(t *testing.T, eventType spi.EventType, err error) eventPublishFunc { //nolint:unparam
 	t.Helper()
 
 	return func(ctx context.Context, topic string, messages ...*spi.Event) error {
 		require.Len(t, messages, 1)
 		require.Equal(t, eventType, messages[0].Type)
 
-		return nil
+		return err
 	}
 }


### PR DESCRIPTION
Added an array of credential fields to the verifier.oidc-interaction-succeeded and verifier.oidc-interaction-claims-retrieved event payloads:
- Credential ID
- Credential types
- Credential subject ID
- Issuer ID