### PR TITLE
refactor: Rename trust-registry request field to credential_matches

### DIFF
--- a/component/wallet-cli/pkg/trustregistry/models.go
+++ b/component/wallet-cli/pkg/trustregistry/models.go
@@ -20,7 +20,7 @@ type CredentialOffer struct {
 	CredentialType             string `json:"credential_type,omitempty"`
 }
 
-type CredentialMetadata struct {
+type CredentialMatches struct {
 	CredentialID    string   `json:"credential_id,omitempty"`
 	CredentialTypes []string `json:"credential_types,omitempty"`
 	ExpirationDate  string   `json:"expiration_date,omitempty"`
@@ -30,9 +30,9 @@ type CredentialMetadata struct {
 
 // WalletPresentationRequest is a request model for wallet presentation policy evaluation.
 type WalletPresentationRequest struct {
-	CredentialMetadata []CredentialMetadata `json:"credential_metadata"`
-	VerifierDID        string               `json:"verifier_did"`
-	VerifierDomain     string               `json:"verifier_domain,omitempty"`
+	CredentialMatches []CredentialMatches `json:"credential_matches"`
+	VerifierDID       string              `json:"verifier_did"`
+	VerifierDomain    string              `json:"verifier_domain,omitempty"`
 }
 
 type PolicyEvaluationResponse struct {

--- a/component/wallet-cli/pkg/trustregistry/trustregistry.go
+++ b/component/wallet-cli/pkg/trustregistry/trustregistry.go
@@ -88,15 +88,15 @@ func (c *Client) ValidateVerifier(
 	logger.Debug("verifier validation begin", log.WithURL(endpoint))
 
 	req := &WalletPresentationRequest{
-		VerifierDID:        verifierDID,
-		VerifierDomain:     verifierDomain,
-		CredentialMetadata: make([]CredentialMetadata, len(credentials)),
+		VerifierDID:       verifierDID,
+		VerifierDomain:    verifierDomain,
+		CredentialMatches: make([]CredentialMatches, len(credentials)),
 	}
 
 	for i, credential := range credentials {
 		content := credential.Contents()
 
-		req.CredentialMetadata[i] = getCredentialMetadata(content)
+		req.CredentialMatches[i] = getCredentialMatches(content)
 	}
 
 	body, err := json.Marshal(req)
@@ -122,7 +122,7 @@ func (c *Client) ValidateVerifier(
 	return resp.Payload != nil && lo.FromPtr(resp.Payload)["attestations_required"] != nil, nil
 }
 
-func getCredentialMetadata(content verifiable.CredentialContents) CredentialMetadata {
+func getCredentialMatches(content verifiable.CredentialContents) CredentialMatches {
 	var iss, exp string
 	if content.Issued != nil {
 		iss = content.Issued.FormatToString()
@@ -132,7 +132,7 @@ func getCredentialMetadata(content verifiable.CredentialContents) CredentialMeta
 		exp = content.Expired.FormatToString()
 	}
 
-	return CredentialMetadata{
+	return CredentialMatches{
 		CredentialID:    content.ID,
 		CredentialTypes: content.Types,
 		ExpirationDate:  exp,

--- a/pkg/service/oidc4vp/oidc4vp_service.go
+++ b/pkg/service/oidc4vp/oidc4vp_service.go
@@ -517,7 +517,7 @@ func (s *Service) checkPolicy(
 
 	st := time.Now()
 
-	metadata := make([]trustregistry.CredentialMetadata, 0)
+	matches := make([]trustregistry.CredentialMatches, 0)
 
 	for _, token := range vpTokens {
 		for _, credential := range token.Presentation.Credentials() {
@@ -533,7 +533,7 @@ func (s *Service) checkPolicy(
 				exp = vcc.Expired.FormatToString()
 			}
 
-			metadata = append(metadata, trustregistry.CredentialMetadata{
+			matches = append(matches, trustregistry.CredentialMatches{
 				CredentialID: vcc.ID,
 				Types:        vcc.Types,
 				IssuerID:     vcc.Issuer.ID,
@@ -547,8 +547,8 @@ func (s *Service) checkPolicy(
 		ctx,
 		profile,
 		&trustregistry.ValidatePresentationData{
-			AttestationVP:      attestationVP,
-			CredentialMetadata: metadata,
+			AttestationVP:     attestationVP,
+			CredentialMatches: matches,
 		},
 	); err != nil {
 		return fmt.Errorf("check policy: %w", err)

--- a/pkg/service/trustregistry/api.go
+++ b/pkg/service/trustregistry/api.go
@@ -34,8 +34,8 @@ type ValidatePresentation interface {
 }
 
 type ValidatePresentationData struct {
-	AttestationVP      string
-	CredentialMetadata []CredentialMetadata
+	AttestationVP     string
+	CredentialMatches []CredentialMatches
 }
 
 // ServiceInterface defines an interface for Trust Registry service.
@@ -44,8 +44,8 @@ type ServiceInterface interface {
 	ValidatePresentation
 }
 
-// CredentialMetadata represents metadata of matched credentials for policy evaluation.
-type CredentialMetadata struct {
+// CredentialMatches represents metadata of matched credentials for policy evaluation.
+type CredentialMatches struct {
 	// Credential ID
 	CredentialID string `json:"credential_id"`
 	// Credential Types.
@@ -67,9 +67,9 @@ type IssuancePolicyEvaluationRequest struct {
 
 // PresentationPolicyEvaluationRequest is a request payload for presentation policy evaluation service.
 type PresentationPolicyEvaluationRequest struct {
-	AttestationVC      *[]string            `json:"attestation_vc,omitempty"`
-	CredentialMetadata []CredentialMetadata `json:"credential_metadata"`
-	VerifierDID        string               `json:"verifier_did"`
+	AttestationVC     *[]string           `json:"attestation_vc,omitempty"`
+	CredentialMatches []CredentialMatches `json:"credential_matches"`
+	VerifierDID       string              `json:"verifier_did"`
 }
 
 // PolicyEvaluationResponse is a response from policy evaluation service.

--- a/pkg/service/trustregistry/trustregistry_service.go
+++ b/pkg/service/trustregistry/trustregistry_service.go
@@ -157,8 +157,8 @@ func (s *Service) ValidatePresentation(
 	}
 
 	req := &PresentationPolicyEvaluationRequest{
-		VerifierDID:        profile.SigningDID.DID,
-		CredentialMetadata: data.CredentialMetadata,
+		VerifierDID:       profile.SigningDID.DID,
+		CredentialMatches: data.CredentialMatches,
 	}
 
 	if data.AttestationVP != "" {

--- a/pkg/service/trustregistry/trustregistry_service_test.go
+++ b/pkg/service/trustregistry/trustregistry_service_test.go
@@ -533,8 +533,8 @@ func TestService_ValidatePresentation(t *testing.T) {
 					context.Background(),
 					profile,
 					&trustregistry.ValidatePresentationData{
-						AttestationVP:      attestationVP,
-						CredentialMetadata: nil,
+						AttestationVP:     attestationVP,
+						CredentialMatches: nil,
 					},
 				),
 			)

--- a/test/bdd/trustregistry/models.go
+++ b/test/bdd/trustregistry/models.go
@@ -22,9 +22,9 @@ type CredentialOffer struct {
 
 // WalletPresentationRequest is a model for wallet presentation policy evaluation.
 type WalletPresentationRequest struct {
-	CredentialMetadata []CredentialMetadata `json:"credential_metadata"`
-	VerifierDID        string               `json:"verifier_did"`
-	VerifierDomain     *string              `json:"verifier_domain,omitempty"`
+	CredentialMatches []CredentialMatches `json:"credential_matches"`
+	VerifierDID       string              `json:"verifier_did"`
+	VerifierDomain    *string             `json:"verifier_domain,omitempty"`
 }
 
 // IssuerIssuanceRequest is a model for issuer issuance policy evaluation.
@@ -36,13 +36,13 @@ type IssuerIssuanceRequest struct {
 
 // VerifierPresentationRequest is a model for verifier presentation policy evaluation.
 type VerifierPresentationRequest struct {
-	AttestationVC      *[]string            `json:"attestation_vc,omitempty"`
-	CredentialMetadata []CredentialMetadata `json:"credential_metadata"`
-	VerifierDID        string               `json:"verifier_did"`
+	AttestationVC     *[]string           `json:"attestation_vc,omitempty"`
+	CredentialMatches []CredentialMatches `json:"credential_matches"`
+	VerifierDID       string              `json:"verifier_did"`
 }
 
-// CredentialMetadata defines model for CredentialMetadata.
-type CredentialMetadata struct {
+// CredentialMatches defines model for credential matches.
+type CredentialMatches struct {
 	CredentialID    *string   `json:"credential_id,omitempty"`
 	CredentialTypes *[]string `json:"credential_types,omitempty"`
 	ExpirationDate  *string   `json:"expiration_date,omitempty"`

--- a/test/bdd/trustregistry/server.go
+++ b/test/bdd/trustregistry/server.go
@@ -97,7 +97,7 @@ func (s *server) evaluateWalletPresentationPolicy(w http.ResponseWriter, r *http
 		return
 	}
 
-	if len(request.CredentialMetadata) == 0 {
+	if len(request.CredentialMatches) == 0 {
 		s.writeResponse(
 			w, http.StatusBadRequest, "no credential metadata supplied")
 
@@ -183,7 +183,7 @@ func (s *server) evaluateVerifierPresentationPolicy(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if request.CredentialMetadata == nil || len(request.CredentialMetadata) == 0 {
+	if request.CredentialMatches == nil || len(request.CredentialMatches) == 0 {
 		s.writeResponse(
 			w, http.StatusBadRequest, "no credential metadata supplied")
 


### PR DESCRIPTION
The trust-registry wallet presentation and verifier requests were updated such that the field, credential_metadata, was renamed to credential_matches.