### PR TITLE
feat: Added VC model parameter to issuer profile config

### DIFF
--- a/pkg/doc/verifiable/format.go
+++ b/pkg/doc/verifiable/format.go
@@ -15,6 +15,13 @@ type OIDCFormat string
 
 type Format string
 
+type Model string
+
+const (
+	V1_1 Model = "w3c-vc-1.1"
+	V2_0 Model = "w3c-vc-2.0"
+)
+
 // For mapping between Format and OIDCFormat see oidc4ci.SelectProperOIDCFormat.
 const (
 	Jwt Format = "jwt"

--- a/pkg/profile/api.go
+++ b/pkg/profile/api.go
@@ -184,6 +184,7 @@ type OIDCConfig struct {
 
 // VCConfig describes how to sign verifiable credentials.
 type VCConfig struct {
+	Model                   vcsverifiable.Model                `json:"model,omitempty"`
 	Format                  vcsverifiable.Format               `json:"format,omitempty"`
 	SigningAlgorithm        vcsverifiable.SignatureType        `json:"signingAlgorithm,omitempty"`
 	KeyType                 kms.KeyType                        `json:"keyType,omitempty"`

--- a/test/bdd/features/oidc4vc_api.feature
+++ b/test/bdd/features/oidc4vc_api.feature
@@ -50,13 +50,25 @@ Feature: OIDC4VC REST API
     And Verifier with profile "<verifierProfile>" requests deleted interactions claims
 
     Examples:
-      | issuerProfile                         | credentialType             | clientRegistrationMethod | credentialTemplate               | verifierProfile      | presentationDefinitionID                     | fields                                                       |
+      | issuerProfile                         | credentialType             | clientRegistrationMethod | credentialTemplate                 | verifierProfile      | presentationDefinitionID                     | fields                                                       |
 #     SDJWT issuer, JWT verifier, no limit disclosure in PD query.
-      | bank_issuer_v2/v1.0                      | UniversityDegreeCredential | dynamic                  | universityDegreeTemplateID       | v_myprofile_jwt/v1.0 | 32f54163-no-limit-disclosure-single-field    | degree_type_id                                               |
+      | bank_issuer_v2/v1.0                   | UniversityDegreeCredential | dynamic                  | universityDegreeTemplateID         | v_myprofile_jwt/v1.0 | 32f54163-no-limit-disclosure-single-field    | degree_type_id                                               |
 #     SDJWT issuer, JWT verifier, limit disclosure and optional fields in PD query.
-      | bank_issuer_v2/v1.0                      | CrudeProductCredential     | discoverable             | crudeProductCredentialTemplateID | v_myprofile_jwt/v1.0 | 3c8b1d9a-limit-disclosure-optional-fields    | unit_of_measure_barrel,api_gravity,category,supplier_address |
+      | bank_issuer_v2/v1.0                   | CrudeProductCredential     | discoverable             | crudeProductCredentialV2TemplateID | v_myprofile_jwt/v1.0 | 3c8b1d9a-limit-disclosure-optional-fields    | unit_of_measure_barrel,api_gravity,category,supplier_address |
 #     JWT issuer, JWT verifier, no limit disclosure and optional fields in PD query.
-      | i_myprofile_ud_es256k_jwt_v2/v1.0        | PermanentResidentCard      | pre-registered           | permanentResidentCardTemplateID  | v_myprofile_jwt/v1.0 | 32f54163-no-limit-disclosure-optional-fields | lpr_category_id,registration_city,commuter_classification    |
+      | i_myprofile_ud_es256k_jwt_v2/v1.0     | PermanentResidentCard      | pre-registered           | permanentResidentCardTemplateID    | v_myprofile_jwt/v1.0 | 32f54163-no-limit-disclosure-optional-fields | lpr_category_id,registration_city,commuter_classification    |
+
+  @oidc4vc_rest_auth_flow_fail
+  Scenario Outline: OIDC credential issuance and verification Auth flow negative tests
+    Given Profile "<issuerProfile>" issuer has been authorized with username "profile-user-issuer-1" and password "profile-user-issuer-1-pwd"
+    And  User holds credential "<credentialType>" with templateID "<credentialTemplate>"
+    And Profile "<verifierProfile>" verifier has been authorized with username "profile-user-verifier-1" and password "profile-user-verifier-1-pwd"
+    When User interacts with Wallet to initiate credential issuance using authorization code flow with client registration method "<clientRegistrationMethod>" and receives "invalid context for model w3c-vc-2.0" error
+
+    Examples:
+      | issuerProfile                         | credentialType             | clientRegistrationMethod | credentialTemplate               | verifierProfile      | presentationDefinitionID                     | fields                                                       |
+#     SDJWT issuer, JWT verifier, limit disclosure and optional fields in PD query.
+      | bank_issuer_v2/v1.0                   | CrudeProductCredential     | discoverable             | crudeProductCredentialV1TemplateID | v_myprofile_jwt/v1.0 | 3c8b1d9a-limit-disclosure-optional-fields    | unit_of_measure_barrel,api_gravity,category,supplier_address |
 
   @oidc4vc_rest_auth_flow_batch_credential_configuration_id
   Scenario Outline: OIDC Batch credential issuance and verification Auth flow (request all credentials by credentialConfigurationID)

--- a/test/bdd/fixtures/profile/profiles.json
+++ b/test/bdd/fixtures/profile/profiles.json
@@ -935,6 +935,7 @@
         "url": "http://vc-rest-echo.trustbloc.local:8075",
         "active": true,
         "vcConfig": {
+          "model": "w3c-vc-2.0",
           "refreshServiceEnabled": false,
           "signingAlgorithm": "ES256K",
           "signatureRepresentation": 1,
@@ -1666,6 +1667,7 @@
         "url": "http://vc-rest-echo.trustbloc.local:8075",
         "active": true,
         "vcConfig": {
+          "model": "w3c-vc-1.1",
           "refreshServiceEnabled": true,
           "signingAlgorithm": "JsonWebSignature2020",
           "signatureRepresentation": 0,
@@ -1879,6 +1881,7 @@
         "url": "http://vc-rest-echo.trustbloc.local:8075",
         "active": true,
         "vcConfig": {
+          "model": "w3c-vc-2.0",
           "refreshServiceEnabled": false,
           "signingAlgorithm": "JsonWebSignature2020",
           "signatureRepresentation": 0,
@@ -1929,19 +1932,7 @@
             "jsonSchema": "{\"$id\":\"https://trustbloc.com/universitydegree.schema.json\",\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"UniversityDegreeCredential\",\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"spouse\":{\"type\":\"string\"},\"degree\":{\"type\":\"object\",\"description\":\"Describes the degree.\",\"properties\":{\"type\":{\"type\":\"string\"},\"degree\":{\"type\":\"string\"}},\"required\":[\"type\",\"degree\"]}},\"required\":[\"name\",\"spouse\",\"degree\"]}",
             "type": "UniversityDegreeCredential",
             "id": "universityDegreeTemplateID",
-            "issuer": "did:orb:bank_issuer",
-            "checks": {
-              "strict": true
-            }
-          },
-          {
-            "contexts": [
-              "https://www.w3.org/2018/credentials/v1",
-              "https://www.w3.org/2018/credentials/examples/v1"
-            ],
-            "type": "VerifiedEmployee",
-            "id": "templateID",
-            "issuer": "did:orb:bank_issuer",
+            "issuer": "did:orb:bank_issuer_v2",
             "checks": {
               "strict": true
             }
@@ -1953,7 +1944,7 @@
             ],
             "type": "PermanentResidentCard",
             "id": "permanentResidentCardTemplateID",
-            "issuer": "did:orb:bank_issuer",
+            "issuer": "did:orb:bank_issuer_v2",
             "checks": {
               "strict": true
             }
@@ -1964,8 +1955,20 @@
               "https://trustbloc.github.io/context/vc/examples-crude-product-v2.jsonld"
             ],
             "type": "CrudeProductCredential",
-            "id": "crudeProductCredentialTemplateID",
-            "issuer": "did:orb:bank_issuer",
+            "id": "crudeProductCredentialV2TemplateID",
+            "issuer": "did:orb:bank_issuer_v2",
+            "checks": {
+              "strict": true
+            }
+          },
+          {
+            "contexts": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://trustbloc.github.io/context/vc/examples-crude-product-v1.jsonld"
+            ],
+            "type": "CrudeProductCredential",
+            "id": "crudeProductCredentialV1TemplateID",
+            "issuer": "did:orb:bank_issuer_v2",
             "checks": {
               "strict": true
             }

--- a/test/bdd/pkg/v1/oidc4vc/oidc4vci.go
+++ b/test/bdd/pkg/v1/oidc4vc/oidc4vci.go
@@ -1079,6 +1079,19 @@ func (s *Steps) runOIDC4CIAuthWithClientRegistrationMethod(method string) error 
 	return nil
 }
 
+func (s *Steps) runOIDC4CIAuthWithClientRegistrationMethodWithExpectedError(method, expectedError string) error {
+	err := s.runOIDC4CIAuthWithClientRegistrationMethod(method)
+	if err == nil {
+		return fmt.Errorf("error %q expected but got none", expectedError)
+	}
+
+	if !strings.Contains(err.Error(), expectedError) {
+		return fmt.Errorf("unexpected error: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Steps) registerOAuthClient(offerCredentialURL string) (string, error) {
 	u, err := url.Parse(offerCredentialURL)
 	if err != nil {

--- a/test/bdd/pkg/v1/oidc4vc/steps.go
+++ b/test/bdd/pkg/v1/oidc4vc/steps.go
@@ -112,6 +112,7 @@ func (s *Steps) RegisterSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^User interacts with Wallet to initiate credential issuance using authorization code flow with credential configuration ID "([^"]*)"$`, s.runOIDC4VCIAuthWithCredentialConfigurationID)
 	sc.Step(`^User interacts with Wallet to initiate credential issuance using authorization code flow with scopes "([^"]*)"$`, s.runOIDC4VCIAuthWithScopes)
 	sc.Step(`^User interacts with Wallet to initiate credential issuance using authorization code flow with client registration method "([^"]*)"$`, s.runOIDC4CIAuthWithClientRegistrationMethod)
+	sc.Step(`^User interacts with Wallet to initiate credential issuance using authorization code flow with client registration method "([^"]*)" and receives "([^"]*)" error$`, s.runOIDC4CIAuthWithClientRegistrationMethodWithExpectedError)
 	sc.Step(`^User interacts with Wallet to initiate credential issuance using authorization code flow with wallet-initiated$`, s.runOIDC4VCIAuthWalletInitiatedFlow)
 	sc.Step(`^User interacts with Wallet to initiate credential issuance using pre authorization code flow$`, s.runOIDC4CIPreAuthWithValidClaims)
 	sc.Step(`^User interacts with Wallet to initiate batch credential issuance using pre authorization code flow$`, s.runOIDC4VCIPreAuthBatch)


### PR DESCRIPTION
The 'model' parameter on the issuer profile specifies the credential model for the issuer. Supported models are w3c-vc-1.1 and w3c-vc-2.0.