### PR TITLE
chore: Deprecate JAEGER tracing exporter

### DIFF
--- a/cmd/vc-rest/startcmd/params.go
+++ b/cmd/vc-rest/startcmd/params.go
@@ -1110,12 +1110,7 @@ func getTracingParams(cmd *cobra.Command) (*tracingParams, error) {
 		serviceName: serviceName,
 	}
 
-	switch params.exporter {
-	case tracing.None:
-	case tracing.Jaeger:
-	case tracing.Stdout:
-		return params, nil
-	default:
+	if !tracing.IsExportedSupported(params.exporter) {
 		return nil, fmt.Errorf("unsupported otel span exporter: %s", params.exporter)
 	}
 

--- a/pkg/observability/tracing/tracing.go
+++ b/pkg/observability/tracing/tracing.go
@@ -29,8 +29,14 @@ var logger = log.New("tracing")
 type SpanExporterType = string
 
 const (
-	None   SpanExporterType = ""
+	// None is the noop span exporter.
+	None SpanExporterType = ""
+	// Default is the default span exporter to be used with any Open Telemetry-compatible agent.
+	Default SpanExporterType = "DEFAULT"
+	// Jaeger is the Jaeger span exporter.
+	//Deprecated: use Default instead.
 	Jaeger SpanExporterType = "JAEGER"
+	// Stdout is the stdout span exporter.
 	Stdout SpanExporterType = "STDOUT"
 )
 
@@ -56,7 +62,7 @@ func Initialize(exporter SpanExporterType, serviceName string) (func(), trace.Tr
 	)
 
 	switch exporter {
-	case Jaeger:
+	case Default, Jaeger:
 		spanExporter, err = otlptracehttp.New(context.Background())
 		if err != nil {
 			return nil, nil, fmt.Errorf("create OTLP HTTP exporter: %w", err)
@@ -91,4 +97,9 @@ func Initialize(exporter SpanExporterType, serviceName string) (func(), trace.Tr
 			logger.Warn("Error shutting down tracer provider", log.WithError(err))
 		}
 	}, tracerProvider.Tracer(tracerName), nil
+}
+
+// IsExportedSupported returns true if the given exporter is supported.
+func IsExportedSupported(exporter SpanExporterType) bool {
+	return exporter == None || exporter == Default || exporter == Jaeger || exporter == Stdout
 }

--- a/pkg/observability/tracing/tracing_test.go
+++ b/pkg/observability/tracing/tracing_test.go
@@ -21,10 +21,10 @@ func TestInitialize(t *testing.T) {
 		require.NotPanics(t, shutdown)
 	})
 
-	t.Run("Provider JAEGER", func(t *testing.T) {
-		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost")
+	t.Run("Provider DEFAULT", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost")
 
-		shutdown, tracer, err := Initialize("JAEGER", "service1")
+		shutdown, tracer, err := Initialize("DEFAULT", "service1")
 		require.NoError(t, err)
 		require.NotNil(t, shutdown)
 		require.NotNil(t, tracer)
@@ -46,4 +46,11 @@ func TestInitialize(t *testing.T) {
 		require.Nil(t, shutdown)
 		require.Nil(t, tracer)
 	})
+}
+
+func TestIsExportedSupported(t *testing.T) {
+	require.True(t, IsExportedSupported("DEFAULT"))
+	require.True(t, IsExportedSupported("STDOUT"))
+	require.True(t, IsExportedSupported("JAEGER"))
+	require.False(t, IsExportedSupported("unsupported"))
 }

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -37,9 +37,8 @@ services:
       - VC_METRICS_PROVIDER_NAME=prometheus
       - VC_PROM_HTTP_URL=vc-rest-echo.trustbloc.local:48127
       - VC_OAUTH_CLIENTS_FILE_PATH=/oauth-clients/clients.json
-      - OTEL_EXPORTER_TYPE=JAEGER
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:14268
-      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://jaeger.example.com:14268
+      - OTEL_EXPORTER_TYPE=DEFAULT
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger.example.com:4318
       - VC_OIDC4VP_RECEIVED_CLAIMS_DATA_TTL=10s
       - VC_SYSTEM_VERSION=v1.0.0
       - VC_REST_DATA_ENCRYPTION_KEY_ID=bc436485-5092-42b8-92a3-0aa8b93536dc
@@ -278,11 +277,11 @@ services:
 
   jaeger.example.com:
     container_name: jaeger.example.com
-    image: jaegertracing/all-in-one:1.41
+    image: jaegertracing/all-in-one:1.62.0
     ports:
       - 6831:6831/udp
       - 16686:16686
-      - 14268:14268
+      - 4318:4318
     networks:
       - bdd_net
 


### PR DESCRIPTION
Deprecated the JAEGER exporter type and added DEFAULT to the list of supported types. Also fixed the BDD test to work with the latest version of otel.