### PR TITLE
feat: add logic to validate multi proof vc\vp

### DIFF
--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -16,30 +16,9 @@ if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
-lint_tasks=(
-    "."
-    "component/profile/reader/file"
-    "component/event"
-    "component/healthchecks"
-    "component/credentialstatus"
-    "component/oidc/fosite"
-)
-
-run_lint() {
-    local task_dir=$1
-    ${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} \
-        -v $(pwd):/opt/workspace \
-        -w /opt/workspace/$task_dir ${GOLANGCI_LINT_IMAGE} \
-        golangci-lint run --timeout 5m --exclude-files '.*_test\.go'
-}
-
-if [ "$LINT_CONCURRENTLY" = "true" ]; then
-    for task in "${lint_tasks[@]}"; do
-        run_lint "$task" &
-    done
-    wait
-else
-    for task in "${lint_tasks[@]}"; do
-        run_lint "$task"
-    done
-fi
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m --exclude-files '.*_test\.go'
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/profile/reader/file ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m --exclude-files '.*_test\.go'
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/event ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m --exclude-files '.*_test\.go'
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/healthchecks ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m --exclude-files '.*_test\.go'
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/credentialstatus ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m --exclude-files '.*_test\.go'
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/component/oidc/fosite ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m --exclude-files '.*_test\.go'


### PR DESCRIPTION
**VC**
According to the spec https://www.w3.org/TR/vc-data-integrity/#proofs, VC can have multiple proofs (Proof Sets), which is currently supported.

Proof Graphs & Chains are more advanced features that are not currently supported by vcs & vc-go.

**VP**
The spec does not directly mention that the VP should have only 1 Proof because the VP is VC. We will handle it like VC during proof validation.
As we generate options (challenge, domain, etc.) during the OIDC4VP flow, we expect that all proofs will have this option in the presentation.